### PR TITLE
Implementing an interactive map marker - June 2025 Release

### DIFF
--- a/d2d-map-service/views/MapSearchView.swift
+++ b/d2d-map-service/views/MapSearchView.swift
@@ -11,16 +11,22 @@ import CoreLocation
 import UniformTypeIdentifiers   // for .commaSeparatedText
 
 struct MapSearchView: View {
+    // These are bindings passed in from ContentView (or wherever).
     @Binding var region: MKCoordinateRegion
     @Binding var prospects: [Prospect]
-    @Binding var selectedList: String   // ← The shared filter
+    @Binding var selectedList: String   // ← whatever filter you’re using
 
+    // We keep a controller for map logic… (details omitted)
     @StateObject private var controller: MapController
-    @State private var searchText: String = ""
-    
-    @State private var pendingAddress: String?
-    @State private var showOutcomePrompt = false
 
+    // This is the text in the search box:
+    @State private var searchText: String = ""
+
+    // MARK: – NEW STATE PROPERTIES FOR INTERACTIVE TAP
+    /// When you tap a marker, we store its address here…
+    @State private var pendingAddress: String? = nil
+    /// …and show an alert with “Answered / Not Answered”:
+    @State private var showOutcomePrompt = false
 
     init(region: Binding<MKCoordinateRegion>,
          prospects: Binding<[Prospect]>,
@@ -33,24 +39,42 @@ struct MapSearchView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            // ──────────────────────────────────────────────────────────────────
+            // 1) THE MAP WITH TAPPABLE ANNOTATIONS
+            // ──────────────────────────────────────────────────────────────────
             Map(coordinateRegion: $controller.region,
-                annotationItems: controller.markers) { place in
+                 annotationItems: controller.markers) { place in
+
                 MapAnnotation(coordinate: place.location) {
                     Circle()
                         .fill(place.markerColor)
-                        .frame(width: 16, height: 16)
+                        .frame(width: 20, height: 20)
                         .overlay(Circle().stroke(Color.black, lineWidth: 1))
-                        .animation(.easeInOut, value: place.count)
+                        .contentShape(Rectangle()) // defines tappable area
+                        .onTapGesture {
+                            pendingAddress = place.address
+                            showOutcomePrompt = true
+                        }
+                        .allowsHitTesting(true)
+                        .onTapGesture {
+                            print("Tapped marker at \(place.address)")
+                            pendingAddress = place.address
+                            showOutcomePrompt = true
+                        }
                 }
             }
+
             .frame(maxHeight: .infinity)
             .edgesIgnoringSafeArea(.horizontal)
 
+            // ──────────────────────────────────────────────────────────────────
+            // 2) SEARCH BAR (unchanged)
+            // ──────────────────────────────────────────────────────────────────
             HStack {
                 HStack {
                     Image(systemName: "magnifyingglass")
                         .foregroundColor(.gray)
-                    TextField("Enter a knock here...", text: $searchText, onCommit: {
+                    TextField("Enter a knock here…", text: $searchText, onCommit: {
                         let trimmed = searchText.trimmingCharacters(in: .whitespaces)
                         guard !trimmed.isEmpty else { return }
                         handleSearch(query: trimmed)
@@ -68,18 +92,18 @@ struct MapSearchView: View {
 
             Spacer()
         }
+        // ──────────────────────────────────────────────────────────────────
+        // 3) LIFECYCLE / UPDATE MARKERS WHEN PROSPECTS OR SELECTED LIST CHANGES
+        // ──────────────────────────────────────────────────────────────────
         .onAppear {
-            // First appearance: show only markers for `selectedList`
             let filtered = prospects.filter { $0.list == selectedList }
             controller.setMarkers(for: filtered)
         }
         .onChange(of: prospects) { newProspects in
-            // If the array itself changes (new additions or edits), reload markers
             let filtered = newProspects.filter { $0.list == selectedList }
             controller.setMarkers(for: filtered)
         }
         .onChange(of: selectedList) { newList in
-            // When you switch tabs (or pick “Customers”), reload markers for that list
             let filtered = prospects.filter { $0.list == newList }
             controller.setMarkers(for: filtered)
         }
@@ -90,52 +114,68 @@ struct MapSearchView: View {
                 to: nil, from: nil, for: nil
             )
         }
-        .alert("Knock Outcome", isPresented: $showOutcomePrompt, actions: {
+        // ──────────────────────────────────────────────────────────────────
+        // 4) ALERT TO CHOOSE “Answered” OR “Not Answered”
+        // ──────────────────────────────────────────────────────────────────
+        .alert("Knock Outcome",
+               isPresented: $showOutcomePrompt,
+               actions: {
             Button("Answered") {
-                saveKnock(address: pendingAddress!, status: "Answered")
+                // User tapped “Answered”
+                if let addr = pendingAddress {
+                    saveKnock(address: addr, status: "Answered")
+                }
             }
             Button("Not Answered") {
-                saveKnock(address: pendingAddress!, status: "Not Answered")
+                // User tapped “Not Answered”
+                if let addr = pendingAddress {
+                    saveKnock(address: addr, status: "Not Answered")
+                }
             }
-            Button("Cancel", role: .cancel) {}
-        }, message: {
+            Button("Cancel", role: .cancel) {
+                // Nothing to do here
+            }
+        },
+               message: {
             Text("Did someone answer at \(pendingAddress ?? "this address")?")
-        })
-
+        }
+        )
     }
 
+    // Called when the user types something into the search bar and hits Return.
     private func handleSearch(query: String) {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
+        // Instead of geocoding immediately, first ask the user if they want to log “Answered/Not Answered”
         pendingAddress = trimmed
         showOutcomePrompt = true
     }
-    
+
+    // Update your `prospects` array (and the MapController) once the user picks “Answered” / “Not Answered”:
     private func saveKnock(address: String, status: String) {
         let normalized = address.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
 
         if let index = prospects.firstIndex(where: {
             $0.address.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) == normalized
         }) {
+            // If that prospect already exists, bump its count & append to its history:
             prospects[index].count += 1
             prospects[index].knockHistory.append(Knock(date: Date(), status: status))
         } else {
+            // Otherwise, create a brand‐new Prospect with a default name:
             let newProspect = Prospect(
                 id: UUID(),
-                fullName: "New Prospect",
+                fullName: "New Prospect",       // Placeholder name
                 address: address,
                 count: 1,
-                list: "Prospects",
+                list: "Prospects",              // Or whatever default list you want
                 knockHistory: [Knock(date: Date(), status: status)]
             )
-
             prospects.append(newProspect)
         }
 
+        // Finally—actually geocode the address and add/update the marker on the map:
         controller.performSearch(query: address)
     }
-
-
-
 }

--- a/d2d-map-serviceTests/MapControllerTests.swift
+++ b/d2d-map-serviceTests/MapControllerTests.swift
@@ -15,8 +15,8 @@ final class MapControllerTests: XCTestCase {
         // Force release your controller if needed
     }
 
-    func makeProspect(id: UUID = UUID(), name: String, address: String, list: String) -> Prospect {
-        Prospect(id: id, fullName: name, address: address, count: 0, list: list)
+    func makeProspect(id: UUID = UUID(), name: String, address: String, list: String, knockHistory: [Knock] = []) -> Prospect {
+        Prospect(id: id, fullName: name, address: address, count: 0, list: list, knockHistory: knockHistory)
     }
 
 }


### PR DESCRIPTION
The purpose of this PR is to make the map service more interactive. Imagine users are out knocking. The are able to search up an address and log a knock the first time they go through a neighborhood, adding the prospcts along the way. The second time and beyond, they can just load the list and click on each marker to log the knock. Thats what this PR does.