### PR TITLE
Implementing Leaderboard Service V1 - June 2025 Release

### DIFF
--- a/d2d-map-service/views/LeaderboardCardView.swift
+++ b/d2d-map-service/views/LeaderboardCardView.swift
@@ -1,0 +1,29 @@
+//
+//  LeaderboardCard.swift
+//  d2d-map-service
+//
+//  Created by Emin Okic on 6/8/25.
+//
+import Foundation
+import SwiftData
+import SwiftUICore
+
+struct LeaderboardCardView: View {
+    let title: String
+    let count: Int
+
+    var body: some View {
+        VStack {
+            Text(title)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Text("\(count)")
+                .font(.title)
+                .bold()
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(12)
+    }
+}

--- a/d2d-map-service/views/ProfileView.swift
+++ b/d2d-map-service/views/ProfileView.swift
@@ -22,6 +22,7 @@ struct ProfileView: View {
 
     /// A query that fetches all `Prospect` records associated with the current user.
     @Query private var prospects: [Prospect]
+    @Query private var allProspects: [Prospect]        // Global
 
     /// Initializes the profile view with a login state binding and user email.
     /// Filters prospects to only include those associated with the current user.
@@ -41,10 +42,18 @@ struct ProfileView: View {
 
         NavigationView {
             Form {
+                
+                // Get personal and global knock counts
+                let yourKnocks = ProfileController.totalKnocks(from: prospects, userEmail: userEmail)
+                let globalKnocks = ProfileController.totalKnocks(from: allProspects)
+
                 // MARK: Total Knocks Summary
                 Section(header: Text("Summary")) {
-                    Text("Total Knocks: \(totalKnocks)")
-                        .font(.headline)
+                    HStack(spacing: 12) {
+                        LeaderboardCardView(title: "You", count: yourKnocks)
+                        LeaderboardCardView(title: "Global", count: globalKnocks)
+                    }
+                    .padding(.vertical, 8)
                 }
 
                 // MARK: Knocks Grouped by List


### PR DESCRIPTION
The purpose of this PR is to implement the leaderboard service so door knockers can see how they compare to the global user base. This is to implement a more personalized user experience and start creating a network effect.