### PR TITLE
Implementing V1 Of The Prospects Notes Feature - June 2025 Release

### DIFF
--- a/d2d-map-service/models/Note.swift
+++ b/d2d-map-service/models/Note.swift
@@ -1,0 +1,25 @@
+//
+//  Note.swift
+//  d2d-map-service
+//
+//  Created by Emin Okic on 6/8/25.
+//
+
+
+// Note.swift
+
+import Foundation
+import SwiftData
+
+@Model
+class Note {
+    var date: Date
+    var content: String
+    var authorEmail: String
+
+    init(content: String, authorEmail: String, date: Date = Date()) {
+        self.date = date
+        self.content = content
+        self.authorEmail = authorEmail
+    }
+}

--- a/d2d-map-service/models/Prospect.swift
+++ b/d2d-map-service/models/Prospect.swift
@@ -30,6 +30,9 @@ class Prospect {
     
     /// The email of the user who created or owns this prospect.
     var userEmail: String
+    
+    // Add this to your Prospect class:
+    var notes: [Note] = []
 
     /// Initializes a new prospect.
     /// - Parameters:

--- a/d2d-map-service/views/AddNoteView.swift
+++ b/d2d-map-service/views/AddNoteView.swift
@@ -7,7 +7,6 @@
 
 
 // AddNoteView.swift
-
 import SwiftUI
 import SwiftData
 
@@ -16,20 +15,48 @@ struct AddNoteView: View {
 
     @State private var newNoteText = ""
     @Environment(\.modelContext) private var context
+    @FocusState private var isFocused: Bool
 
     var body: some View {
-        VStack(alignment: .leading) {
-            TextField("Add a note...", text: $newNoteText)
-                .textFieldStyle(.roundedBorder)
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                Image(systemName: "note.text")
+                    .font(.title3)
+                    .foregroundColor(.accentColor)
 
-            Button("Post Note") {
-                let note = Note(content: newNoteText, authorEmail: prospect.userEmail)
-                prospect.notes.append(note)
-                newNoteText = ""
-                try? context.save()
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("New Note")
+                        .font(.headline)
+
+                    TextEditor(text: $newNoteText)
+                        .focused($isFocused)
+                        .frame(minHeight: 80)
+                        .padding(8)
+                        .background(RoundedRectangle(cornerRadius: 12).fill(Color(.systemGray6)))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color(.separator), lineWidth: 0.5)
+                        )
+                }
             }
-            .disabled(newNoteText.trimmingCharacters(in: .whitespaces).isEmpty)
+
+            HStack {
+                Spacer()
+                Button {
+                    let note = Note(content: newNoteText, authorEmail: prospect.userEmail)
+                    prospect.notes.append(note)
+                    newNoteText = ""
+                    isFocused = false
+                    try? context.save()
+                } label: {
+                    Label("Post Note", systemImage: "paperplane.fill")
+                        .font(.body.weight(.semibold))
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(newNoteText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
         }
-        .padding(.vertical, 4)
+        .animation(.easeInOut, value: newNoteText)
+        .padding(.vertical, 8)
     }
 }

--- a/d2d-map-service/views/AddNoteView.swift
+++ b/d2d-map-service/views/AddNoteView.swift
@@ -1,0 +1,35 @@
+//
+//  AddNoteView.swift
+//  d2d-map-service
+//
+//  Created by Emin Okic on 6/8/25.
+//
+
+
+// AddNoteView.swift
+
+import SwiftUI
+import SwiftData
+
+struct AddNoteView: View {
+    @Bindable var prospect: Prospect
+
+    @State private var newNoteText = ""
+    @Environment(\.modelContext) private var context
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            TextField("Add a note...", text: $newNoteText)
+                .textFieldStyle(.roundedBorder)
+
+            Button("Post Note") {
+                let note = Note(content: newNoteText, authorEmail: prospect.userEmail)
+                prospect.notes.append(note)
+                newNoteText = ""
+                try? context.save()
+            }
+            .disabled(newNoteText.trimmingCharacters(in: .whitespaces).isEmpty)
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/d2d-map-service/views/EditProspectView.swift
+++ b/d2d-map-service/views/EditProspectView.swift
@@ -44,6 +44,25 @@ struct EditProspectView: View {
 
             // MARK: - Knock History Section
             KnockingHistoryView(prospect: prospect)
+            
+            // Inside Form, after KnockingHistoryView
+
+            Section(header: Text("Notes")) {
+                ForEach(prospect.notes.sorted(by: { $0.date > $1.date }), id: \.date) { note in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(note.content)
+                            .font(.body)
+                        Text("— \(note.authorEmail), \(note.date.formatted(.dateTime.month().day().hour().minute()))")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                // New Note Input
+                AddNoteView(prospect: prospect)
+            }
+            
         }
         .navigationTitle("Edit Prospect")
         .toolbar {

--- a/d2d-map-service/views/EditProspectView.swift
+++ b/d2d-map-service/views/EditProspectView.swift
@@ -25,6 +25,9 @@ struct EditProspectView: View {
     let allLists = ["Prospects", "Customers"]
     
     @Environment(\.modelContext) private var modelContext
+    
+    @State private var showKnockHistory = false
+    @State private var showNotes = false
 
     var body: some View {
         Form {
@@ -42,27 +45,36 @@ struct EditProspectView: View {
             }
             .pickerStyle(.menu)
 
-            // MARK: - Knock History Section
-            KnockingHistoryView(prospect: prospect)
-            
-            // Inside Form, after KnockingHistoryView
-
-            Section(header: Text("Notes")) {
-                ForEach(prospect.notes.sorted(by: { $0.date > $1.date }), id: \.date) { note in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(note.content)
-                            .font(.body)
-                        Text("— \(note.authorEmail), \(note.date.formatted(.dateTime.month().day().hour().minute()))")
-                            .font(.caption)
-                            .foregroundColor(.gray)
-                    }
-                    .padding(.vertical, 4)
+            // MARK: - Knock History Section (Expandable)
+            Section {
+                DisclosureGroup(isExpanded: $showKnockHistory) {
+                    KnockingHistoryView(prospect: prospect)
+                } label: {
+                    Text("Knock History")
+                        .fontWeight(.semibold)
                 }
-
-                // New Note Input
-                AddNoteView(prospect: prospect)
             }
-            
+
+            // MARK: - Notes Section (Expandable)
+            Section {
+                DisclosureGroup(isExpanded: $showNotes) {
+                    ForEach(prospect.notes.sorted(by: { $0.date > $1.date }), id: \.date) { note in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(note.content)
+                                .font(.body)
+                            Text("— \(note.authorEmail), \(note.date.formatted(.dateTime.month().day().hour().minute()))")
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                        }
+                        .padding(.vertical, 4)
+                    }
+
+                    AddNoteView(prospect: prospect)
+                } label: {
+                    Text("Notes")
+                        .fontWeight(.semibold)
+                }
+            }
         }
         .navigationTitle("Edit Prospect")
         .toolbar {

--- a/d2d-map-service/views/KnockingHistoryView.swift
+++ b/d2d-map-service/views/KnockingHistoryView.swift
@@ -19,7 +19,7 @@ struct KnockingHistoryView: View {
     @Bindable var prospect: Prospect
     
     var body: some View {
-        Section(header: Text("Knock History")) {
+        Section() {
             if prospect.knockHistory.isEmpty {
                 // Show message if there are no recorded knocks
                 Text("No knocks recorded yet.")

--- a/d2d-map-service/views/MapSearchView.swift
+++ b/d2d-map-service/views/MapSearchView.swift
@@ -46,6 +46,10 @@ struct MapSearchView: View {
 
     /// SwiftData context for model updates.
     @Environment(\.modelContext) private var modelContext
+    
+    @State private var showNoteInput = false
+    @State private var newNoteText = ""
+    @State private var prospectToNote: Prospect? = nil
 
     // MARK: - Init
 
@@ -124,19 +128,51 @@ struct MapSearchView: View {
                isPresented: $showOutcomePrompt,
                actions: {
             Button("Answered") {
-                if let addr = pendingAddress {
-                    saveKnock(address: addr, status: "Answered")
-                }
+                handleKnockAndPromptNote(status: "Answered")
             }
             Button("Not Answered") {
-                if let addr = pendingAddress {
-                    saveKnock(address: addr, status: "Not Answered")
-                }
+                handleKnockAndPromptNote(status: "Not Answered")
             }
             Button("Cancel", role: .cancel) {}
         }, message: {
             Text("Did someone answer at \(pendingAddress ?? "this address")?")
         })
+        .sheet(isPresented: $showNoteInput) {
+            NavigationView {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Add a note about the knock")
+                        .font(.headline)
+
+                    TextEditor(text: $newNoteText)
+                        .frame(height: 120)
+                        .border(Color.secondary)
+
+                    HStack {
+                        Spacer()
+                        Button("Save") {
+                            if let prospect = prospectToNote {
+                                let note = Note(content: newNoteText, authorEmail: userEmail)
+                                prospect.notes.append(note)
+                                try? modelContext.save()
+                            }
+                            newNoteText = ""
+                            showNoteInput = false
+                        }
+                        .disabled(newNoteText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+                .padding()
+                .navigationTitle("New Note")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") {
+                            newNoteText = ""
+                            showNoteInput = false
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // MARK: - Methods
@@ -156,7 +192,8 @@ struct MapSearchView: View {
     }
 
     /// Saves a knock for the given address and outcome status. Adds a new prospect if necessary.
-    private func saveKnock(address: String, status: String) {
+    @discardableResult
+    private func saveKnock(address: String, status: String) -> Prospect {
         let normalized = address.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
         let now = Date()
         let location = LocationManager.shared.currentLocation
@@ -164,12 +201,16 @@ struct MapSearchView: View {
         let lon = location?.longitude ?? 0.0
 
         var prospectId: Int64?
+        var updatedProspect: Prospect
 
         if let existing = prospects.first(where: {
             $0.address.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) == normalized
         }) {
             existing.count += 1
-            existing.knockHistory.append(Knock(date: now, status: status, latitude: lat, longitude: lon, userEmail: userEmail))
+            existing.knockHistory.append(
+                Knock(date: now, status: status, latitude: lat, longitude: lon, userEmail: userEmail)
+            )
+            updatedProspect = existing
         } else {
             let newProspect = Prospect(
                 fullName: "New Prospect",
@@ -178,10 +219,12 @@ struct MapSearchView: View {
                 list: "Prospects",
                 userEmail: userEmail
             )
-            newProspect.knockHistory = [Knock(date: now, status: status, latitude: lat, longitude: lon, userEmail: userEmail)]
+            newProspect.knockHistory = [
+                Knock(date: now, status: status, latitude: lat, longitude: lon, userEmail: userEmail)
+            ]
             modelContext.insert(newProspect)
+            updatedProspect = newProspect
 
-            // Also insert into SQLite DB
             if let newId = DatabaseController.shared.addProspect(name: newProspect.fullName, addr: newProspect.address) {
                 prospectId = newId
             }
@@ -199,5 +242,16 @@ struct MapSearchView: View {
         }
 
         controller.performSearch(query: address)
+        try? modelContext.save()
+
+        return updatedProspect
+    }
+    
+    private func handleKnockAndPromptNote(status: String) {
+        if let addr = pendingAddress {
+            let prospect = saveKnock(address: addr, status: status)
+            prospectToNote = prospect
+            showNoteInput = true
+        }
     }
 }

--- a/d2d-map-service/views/MapSearchView.swift
+++ b/d2d-map-service/views/MapSearchView.swift
@@ -139,17 +139,15 @@ struct MapSearchView: View {
         })
         .sheet(isPresented: $showNoteInput) {
             NavigationView {
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("Add a note about the knock")
-                        .font(.headline)
+                Form {
+                    Section(header: Text("Note Details")) {
+                        TextEditor(text: $newNoteText)
+                            .frame(minHeight: 100)
+                            .padding(.vertical, 4)
+                    }
 
-                    TextEditor(text: $newNoteText)
-                        .frame(height: 120)
-                        .border(Color.secondary)
-
-                    HStack {
-                        Spacer()
-                        Button("Save") {
+                    Section {
+                        Button("Save Note") {
                             if let prospect = prospectToNote {
                                 let note = Note(content: newNoteText, authorEmail: userEmail)
                                 prospect.notes.append(note)
@@ -161,8 +159,8 @@ struct MapSearchView: View {
                         .disabled(newNoteText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
                 }
-                .padding()
                 .navigationTitle("New Note")
+                .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Cancel") {
@@ -172,6 +170,7 @@ struct MapSearchView: View {
                     }
                 }
             }
+            .tint(.accentColor) // Use system accent
         }
     }
 


### PR DESCRIPTION
This PR aims to add a prospect notes feature to the prospects screen. Why? Because keeping notes is essential to maintaining a relationship with prospects. Thus converting more leads to sales. This PR lets users now add notes for prospects after logging a knock and when adding it manually to a prospect.