### PR TITLE
Implementing A Visual Knocking History Tab In The Prospects Screen - June 2025 Release

### DIFF
--- a/d2d-map-service/controllers/MapController.swift
+++ b/d2d-map-service/controllers/MapController.swift
@@ -138,3 +138,18 @@ class MapController: ObservableObject {
         }
     }
 }
+
+extension MapController {
+    func geocodeAddress(_ address: String) async -> CLLocationCoordinate2D? {
+        return await withCheckedContinuation { continuation in
+            let geocoder = CLGeocoder()
+            geocoder.geocodeAddressString(address) { placemarks, error in
+                if let coordinate = placemarks?.first?.location?.coordinate {
+                    continuation.resume(returning: coordinate)
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+}

--- a/d2d-map-service/views/KnockDotsView.swift
+++ b/d2d-map-service/views/KnockDotsView.swift
@@ -1,0 +1,23 @@
+//
+//  KnockDotsView.swift
+//  d2d-map-service
+//
+//  Created by Emin Okic on 6/19/25.
+//
+import SwiftUI
+import SwiftData
+
+struct KnockDotsView: View {
+    let knocks: [Knock]
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(knocks.prefix(5), id: \.date) { knock in
+                Circle()
+                    .frame(width: 10, height: 10)
+                    .foregroundColor(knock.status == "Answered" ? .green : .red)
+            }
+        }
+        .padding(.top, 4)
+    }
+}

--- a/d2d-map-service/views/ProspectsView.swift
+++ b/d2d-map-service/views/ProspectsView.swift
@@ -88,16 +88,23 @@ struct ProspectsView: View {
                                 Text(prospect.address)
                                     .font(.subheadline)
                                     .foregroundColor(.gray)
+                                
                                 if !prospect.contactPhone.isEmpty {
                                     Text("📞 \(formatPhoneNumber(prospect.contactPhone))")
                                         .font(.subheadline)
                                         .foregroundColor(.blue)
                                 }
+                                
                                 if !prospect.contactEmail.isEmpty {
                                     Text("✉️ \(prospect.contactEmail)")
                                         .font(.subheadline)
                                         .foregroundColor(.blue)
                                 }
+                                
+                                if !prospect.sortedKnocks.isEmpty {
+                                        KnockDotsView(knocks: prospect.sortedKnocks)
+                                }
+                                
                             }
                             .padding(.vertical, 4)
                         }

--- a/d2d-map-service/views/ProspectsView.swift
+++ b/d2d-map-service/views/ProspectsView.swift
@@ -24,11 +24,19 @@ struct ProspectsView: View {
 
     let availableLists = ["Prospects", "Customers"]
     @Query var prospects: [Prospect]
+    
+    var onDoubleTap: ((Prospect) -> Void)? = nil
 
-    init(selectedList: Binding<String>, userEmail: String, onSave: @escaping () -> Void) {
+    init(
+        selectedList: Binding<String>,
+        userEmail: String,
+        onSave: @escaping () -> Void,
+        onDoubleTap: ((Prospect) -> Void)? = nil
+    ) {
         _selectedList = selectedList
         self.userEmail = userEmail
         self.onSave = onSave
+        self.onDoubleTap = onDoubleTap
         _prospects = Query(filter: #Predicate<Prospect> { $0.userEmail == userEmail })
     }
 
@@ -63,34 +71,36 @@ struct ProspectsView: View {
                     let filteredProspects = prospects.filter { $0.list == selectedList }
 
                     ForEach(filteredProspects, id: \.persistentModelID) { prospect in
-                        Button {
-                            selectedProspectID = prospect.persistentModelID
-                        } label: {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(prospect.fullName)
-                                    .font(.headline)
-                                Text(prospect.address)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(prospect.fullName)
+                                .font(.headline)
+                            Text(prospect.address)
+                                .font(.subheadline)
+                                .foregroundColor(.gray)
+                            
+                            if !prospect.contactPhone.isEmpty {
+                                Text("📞 \(formatPhoneNumber(prospect.contactPhone))")
                                     .font(.subheadline)
-                                    .foregroundColor(.gray)
-                                
-                                if !prospect.contactPhone.isEmpty {
-                                    Text("📞 \(formatPhoneNumber(prospect.contactPhone))")
-                                        .font(.subheadline)
-                                        .foregroundColor(.blue)
-                                }
-                                
-                                if !prospect.contactEmail.isEmpty {
-                                    Text("✉️ \(prospect.contactEmail)")
-                                        .font(.subheadline)
-                                        .foregroundColor(.blue)
-                                }
-                                
-                                if !prospect.sortedKnocks.isEmpty {
-                                        KnockDotsView(knocks: prospect.sortedKnocks)
-                                }
-                                
+                                    .foregroundColor(.blue)
                             }
-                            .padding(.vertical, 4)
+                            
+                            if !prospect.contactEmail.isEmpty {
+                                Text("✉️ \(prospect.contactEmail)")
+                                    .font(.subheadline)
+                                    .foregroundColor(.blue)
+                            }
+                            
+                            if !prospect.sortedKnocks.isEmpty {
+                                KnockDotsView(knocks: prospect.sortedKnocks)
+                            }
+                        }
+                        .padding(.vertical, 4)
+                        .contentShape(Rectangle()) // Makes the whole row tappable
+                        .onTapGesture(count: 1) {
+                            selectedProspectID = prospect.persistentModelID
+                        }
+                        .onTapGesture(count: 2) {
+                            onDoubleTap?(prospect)
                         }
                         .background(
                             NavigationLink(

--- a/d2d-map-service/views/ProspectsView.swift
+++ b/d2d-map-service/views/ProspectsView.swift
@@ -60,22 +60,6 @@ struct ProspectsView: View {
                     .listRowInsets(EdgeInsets())
                     .listRowSeparator(.hidden)
 
-                    if selectedList == "Prospects" {
-                        Section {
-                            Button {
-                                showingAddProspect = true
-                            } label: {
-                                HStack {
-                                    Image(systemName: "plus.circle.fill")
-                                    Text("Add Prospect")
-                                        .fontWeight(.semibold)
-                                }
-                                .foregroundColor(.blue)
-                                .padding(.vertical, 4)
-                            }
-                        }
-                    }
-
                     let filteredProspects = prospects.filter { $0.list == selectedList }
 
                     ForEach(filteredProspects, id: \.persistentModelID) { prospect in
@@ -116,6 +100,22 @@ struct ProspectsView: View {
                             ) { EmptyView() }
                             .hidden()
                         )
+                    }
+                    
+                    if selectedList == "Prospects" {
+                        Section {
+                            Button {
+                                showingAddProspect = true
+                            } label: {
+                                HStack {
+                                    Image(systemName: "plus.circle.fill")
+                                    Text("Add Prospect")
+                                        .fontWeight(.semibold)
+                                }
+                                .foregroundColor(.blue)
+                                .padding(.vertical, 4)
+                            }
+                        }
                     }
 
                     if selectedList == "Prospects", let suggestion = suggestedProspect {

--- a/d2d-map-service/views/RootView.swift
+++ b/d2d-map-service/views/RootView.swift
@@ -35,31 +35,37 @@ struct RootView: View {
 
     /// Controls the presentation of the Add Prospect sheet (used in child view).
     @State private var showingAddProspect = false
+    
+    @State private var selectedTab = 0
+    @State private var addressToCenter: String? = nil
 
     var body: some View {
-        TabView {
-            // MARK: - Map Tab
+        TabView(selection: $selectedTab) {
             MapSearchView(
                 region: $region,
                 selectedList: $selectedList,
-                userEmail: userEmail
+                userEmail: userEmail,
+                addressToCenter: $addressToCenter
             )
             .tabItem {
                 Label("Map", systemImage: "map.fill")
             }
+            .tag(0)
 
-            // MARK: - Prospects Tab
             ProspectsView(
                 selectedList: $selectedList,
-                userEmail: userEmail
-            ) {
-                showingAddProspect = false
-            }
+                userEmail: userEmail,
+                onSave: { showingAddProspect = false },
+                onDoubleTap: { prospect in
+                    selectedTab = 0
+                    addressToCenter = prospect.address
+                }
+            )
             .tabItem {
                 Label("Prospects", systemImage: "person.3.fill")
             }
+            .tag(1)
 
-            // MARK: - Profile Tab
             ProfileView(
                 isLoggedIn: $isLoggedIn,
                 userEmail: userEmail
@@ -67,6 +73,7 @@ struct RootView: View {
             .tabItem {
                 Label("Profile", systemImage: "person.crop.circle")
             }
+            .tag(2)
         }
     }
 }


### PR DESCRIPTION
This PR aims to let users easily see the interaction history with a prospect by making a UI component in the prospects record. This also lets users find prospects on the map faster by letting users double click prospects to locate them.