### PR TITLE
Implementing The Objections Component - June 2025 Release

### DIFF
--- a/d2d-map-service/controllers/ObjectionManager.swift
+++ b/d2d-map-service/controllers/ObjectionManager.swift
@@ -1,0 +1,14 @@
+//
+//  ObjectionManager.swift
+//  d2d-map-service
+//
+//  Created by Emin Okic on 6/29/25.
+//
+import SwiftUI
+import SwiftData
+
+class ObjectionManager {
+    func delete(_ objection: Objection, from context: ModelContext) {
+        context.delete(objection)
+    }
+}

--- a/d2d-map-service/d2d_map_serviceApp.swift
+++ b/d2d-map-service/d2d_map_serviceApp.swift
@@ -30,27 +30,27 @@ struct d2d_map_serviceApp: App {
 /// This container supports models for `Prospect`, and`Knock`
 /// It persists data in a file located at: `ApplicationSupport/d2d-map-service/database/prospects.sqlite`
 let sharedModelContainer: ModelContainer = {
-    // Determine the path to the database file
     let url = FileManager.default
         .urls(for: .applicationSupportDirectory, in: .userDomainMask)
         .first!
         .appendingPathComponent("d2d-map-service/database/prospects.sqlite")
 
-    // Ensure the directory exists
     try? FileManager.default.createDirectory(
         at: url.deletingLastPathComponent(),
         withIntermediateDirectories: true
     )
 
-    // Configure the model container with a custom URL
-    let config = ModelConfiguration(url: url)
+    let schema = Schema([
+        Prospect.self,
+        Knock.self,
+        Trip.self,
+        Objection.self
+    ])
+
+    let config = ModelConfiguration(schema: schema, url: url)
 
     do {
-        // Load the model container for the specified model types
-        return try ModelContainer(
-                    for: Prospect.self, Knock.self, Trip.self,
-                    configurations: config
-                )
+        return try ModelContainer(for: schema, configurations: [config])
     } catch {
         fatalError("Failed to load ModelContainer: \(error)")
     }

--- a/d2d-map-service/models/Objection.swift
+++ b/d2d-map-service/models/Objection.swift
@@ -1,0 +1,31 @@
+//
+//  Objection.swift
+//  d2d-map-service
+//
+//  Created by Emin Okic on 6/29/25.
+//
+import Foundation
+import SwiftData
+
+@Model
+final class Objection: Hashable {
+    var text: String
+    var response: String
+    var timesHeard: Int
+
+    init(text: String, response: String = "", timesHeard: Int = 0) {
+        self.text = text
+        self.response = response
+        self.timesHeard = timesHeard
+    }
+
+    static func == (lhs: Objection, rhs: Objection) -> Bool {
+        return lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+extension Objection: Identifiable {}

--- a/d2d-map-service/models/RankedObjection.swift
+++ b/d2d-map-service/models/RankedObjection.swift
@@ -1,0 +1,20 @@
+//
+//  RankedObjection.swift
+//  d2d-map-service
+//
+//  Created by Emin Okic on 6/29/25.
+//
+import Foundation
+import SwiftData
+
+struct RankedObjection: Identifiable {
+    let id: PersistentIdentifier
+    let rank: Int
+    let objection: Objection
+
+    init(rank: Int, objection: Objection) {
+        self.rank = rank
+        self.objection = objection
+        self.id = objection.id
+    }
+}

--- a/d2d-map-service/views/AddObjectionView.swift
+++ b/d2d-map-service/views/AddObjectionView.swift
@@ -1,0 +1,46 @@
+//
+//  AddObjectionView.swift
+//  d2d-map-service
+//
+//  Created by Emin Okic on 6/29/25.
+//
+import SwiftUI
+import SwiftData
+
+struct AddObjectionView: View {
+    @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var text: String = ""
+    @State private var response: String = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Objection")) {
+                    TextField("e.g. 'Not interested'", text: $text)
+                }
+
+                Section(header: Text("Suggested Response")) {
+                    TextField("e.g. 'Sure, but can I ask why?'", text: $response)
+                }
+            }
+            .navigationTitle("New Objection")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        let new = Objection(text: text, response: response)
+                        context.insert(new)
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/d2d-map-service/views/EditObjectionView.swift
+++ b/d2d-map-service/views/EditObjectionView.swift
@@ -1,0 +1,54 @@
+//
+//  EditObjectionView.swift
+//  d2d-map-service
+//
+//  Created by Emin Okic on 6/29/25.
+//
+import SwiftUI
+
+struct EditObjectionView: View {
+    @Environment(\.dismiss) var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Bindable var objection: Objection
+
+    private let manager = ObjectionManager()
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                Form {
+                    Section(header: Text("Objection")) {
+                        TextField("Objection text", text: $objection.text)
+                    }
+                    Section(header: Text("Expected Response")) {
+                        TextField("Response", text: $objection.response)
+                    }
+                    Section(header: Text("Times Heard")) {
+                        Stepper("\(objection.timesHeard)", value: $objection.timesHeard, in: 0...1000)
+                    }
+                }
+
+                Button(role: .destructive) {
+                    manager.delete(objection, from: modelContext)
+                    dismiss()
+                } label: {
+                    Label("Delete Objection", systemImage: "trash")
+                        .foregroundColor(.red)
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(Color.red.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+                .padding()
+            }
+            .navigationTitle("Edit Objection")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/d2d-map-service/views/ObjectionsSectionView.swift
+++ b/d2d-map-service/views/ObjectionsSectionView.swift
@@ -1,0 +1,79 @@
+//
+//  ObjectionsSectionView.swift
+//  d2d-map-service
+//
+//  Created by Emin Okic on 6/29/25.
+//
+import SwiftUI
+import SwiftData
+
+struct ObjectionsSectionView: View {
+    @Query private var objections: [Objection]
+    @State private var selectedObjection: Objection?
+    @State private var showingAddObjection = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Objections")
+                    .font(.headline)
+                Spacer()
+                Button {
+                    showingAddObjection = true
+                } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.title3)
+                }
+            }
+            .padding(.horizontal, 20)
+
+            if objections.isEmpty {
+                Text("No objections recorded yet.")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                    .padding(.horizontal, 20)
+            } else {
+                let ranked = objections
+                    .sorted { $0.timesHeard > $1.timesHeard }
+                    .enumerated()
+                    .map { RankedObjection(rank: $0.offset + 1, objection: $0.element) }
+
+                // In ObjectionsSectionView.swift
+                List(ranked) { ranked in
+                    Button {
+                        selectedObjection = ranked.objection
+                    } label: {
+                        HStack {
+                            Text("#\(ranked.rank)")
+                                .frame(width: 40, alignment: .leading)
+                            VStack(alignment: .leading) {
+                                Text(ranked.objection.text)
+                                    .font(.headline)
+                                if !ranked.objection.response.isEmpty {
+                                    Text(ranked.objection.response)
+                                        .font(.subheadline)
+                                        .foregroundColor(.gray)
+                                }
+                            }
+                            Spacer()
+                            Text("×\(ranked.objection.timesHeard)")
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+                .listStyle(.plain)
+                .padding(.horizontal, 20)
+            }
+        }
+        .sheet(item: $selectedObjection) { obj in
+            EditObjectionView(objection: obj)
+        }
+        .sheet(isPresented: $showingAddObjection) {
+            AddObjectionView()
+        }
+        .onAppear {
+            print("📦 Loaded objections: \(objections.map(\.text))")
+        }
+    }
+}

--- a/d2d-map-service/views/ProfileView.swift
+++ b/d2d-map-service/views/ProfileView.swift
@@ -11,6 +11,9 @@ import SwiftData
 struct ProfileView: View {
     @Query private var prospects: [Prospect]
     @Query private var trips: [Trip]
+    
+    @State private var selectedObjection: Objection?
+    @State private var showingAddObjection = false
 
     var body: some View {
         let totalKnocks = ProfileController.totalKnocks(from: prospects)
@@ -93,6 +96,14 @@ struct ProfileView: View {
                         .frame(height: 160)
                         .padding(.horizontal, 20)
                     }
+                    
+                    Spacer()
+                    
+                    // MARK: - Objections Table
+                    NavigationView {
+                        ObjectionsSectionView()
+                    }
+                    
 
                     Spacer()
                 }


### PR DESCRIPTION
This PR aims to let users logs objections in the app so they can see all their biggest objections in the profile screen. The next step includes adding in a step in the log knock workflow to let users log the objection reason before adding a note, tying that note to the objection reason, logging the knock with objection, all if the user enters "Rejected" after logging a knock on the map search view.