### PR TITLE
Implementing Rejections Tracker For Prospecting Screen - July 2025 Release

### DIFF
--- a/d2d-map-service/views/MapSearchView.swift
+++ b/d2d-map-service/views/MapSearchView.swift
@@ -81,35 +81,22 @@ struct MapSearchView: View {
                 .frame(maxHeight: .infinity)
                 .edgesIgnoringSafeArea(.horizontal)
 
-                HStack {
-                    HStack {
-                        Image(systemName: "magnifyingglass").foregroundColor(.gray)
-                        TextField("Enter a knock here…", text: $searchText, onCommit: {
-                            let trimmed = searchText.trimmingCharacters(in: .whitespaces)
-                            guard !trimmed.isEmpty else { return }
-                            handleSearch(query: trimmed)
-                        })
-                        .foregroundColor(.primary)
-                        .autocapitalization(.words)
-                    }
-                    .padding(12)
-                    .background(.ultraThinMaterial)
-                    .cornerRadius(12)
-                    .shadow(radius: 3, x: 0, y: 2)
-                }
-                .padding(.horizontal)
-                .padding(.top, 12)
-
                 Spacer()
             }
             
-            HStack {
-                
+            VStack {
                 RejectionTrackerView(count: totalRejectionsSinceLastSignup)
                     .background(.ultraThinMaterial)
                     .cornerRadius(16)
                     .shadow(radius: 4)
-                    .padding(.horizontal)
+                    .padding(.top, 10)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                
+                Spacer()
+            }
+            .zIndex(1) // Make sure it stays on top
+            
+            HStack {
                 
                 Button {
                     showOnboarding = true
@@ -120,12 +107,35 @@ struct MapSearchView: View {
                         .padding(8)
                         .background(Circle().fill(Color.blue.opacity(0.8)))
                 }
-                .padding()
+                .padding(20)
                 .contentShape(Circle()) // Ensures the entire visual area is tappable
                 
             }
             .transition(.move(edge: .top).combined(with: .opacity))
             .animation(.spring(), value: totalRejectionsSinceLastSignup)
+            
+            VStack {
+                Spacer()
+                
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundColor(.gray)
+                    TextField("Enter a knock here…", text: $searchText, onCommit: {
+                        let trimmed = searchText.trimmingCharacters(in: .whitespaces)
+                        guard !trimmed.isEmpty else { return }
+                        handleSearch(query: trimmed)
+                    })
+                    .foregroundColor(.primary)
+                    .autocapitalization(.words)
+                }
+                .padding(12)
+                .background(.ultraThinMaterial)
+                .cornerRadius(12)
+                .shadow(radius: 3, x: 0, y: 2)
+                .padding(.horizontal)
+                .padding(.bottom, 32) // Adjust this to float higher or lower
+            }
+            
         }
         .fullScreenCover(isPresented: $showOnboarding) {
             OnboardingFlowView(isPresented: $showOnboarding)

--- a/d2d-map-service/views/MapSearchView.swift
+++ b/d2d-map-service/views/MapSearchView.swift
@@ -51,7 +51,8 @@ struct MapSearchView: View {
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            VStack(spacing: 0) {
+            VStack(spacing: 12) {
+                
                 Map(coordinateRegion: $controller.region,
                     annotationItems: controller.markers) { place in
                     MapAnnotation(coordinate: place.location) {
@@ -102,17 +103,29 @@ struct MapSearchView: View {
                 Spacer()
             }
             
-            Button {
-                showOnboarding = true
-            } label: {
-                Image(systemName: "questionmark.circle.fill")
-                    .font(.system(size: 20))
-                    .foregroundColor(.white)
-                    .padding(8)
-                    .background(Circle().fill(Color.blue.opacity(0.8)))
+            HStack {
+                
+                RejectionTrackerView(count: totalRejectionsSinceLastSignup)
+                    .background(.ultraThinMaterial)
+                    .cornerRadius(16)
+                    .shadow(radius: 4)
+                    .padding(.horizontal)
+                
+                Button {
+                    showOnboarding = true
+                } label: {
+                    Image(systemName: "questionmark.circle.fill")
+                        .font(.system(size: 20))
+                        .foregroundColor(.white)
+                        .padding(8)
+                        .background(Circle().fill(Color.blue.opacity(0.8)))
+                }
+                .padding()
+                .contentShape(Circle()) // Ensures the entire visual area is tappable
+                
             }
-            .padding()
-            .contentShape(Circle()) // Ensures the entire visual area is tappable
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .animation(.spring(), value: totalRejectionsSinceLastSignup)
         }
         .fullScreenCover(isPresented: $showOnboarding) {
             OnboardingFlowView(isPresented: $showOnboarding)
@@ -258,6 +271,20 @@ struct MapSearchView: View {
                 }
             }
         }
+    }
+    
+    private var totalRejectionsSinceLastSignup: Int {
+        let allKnocks = prospects.flatMap { $0.knockHistory }
+            .sorted(by: { $0.date > $1.date })
+
+        var count = 0
+        for knock in allKnocks {
+            if knock.status == "Signed Up" { break }
+            if knock.status == "Not Answered" || knock.status == "Not Enough Interest" {
+                count += 1
+            }
+        }
+        return count
     }
 
     private func updateMarkers() {

--- a/d2d-map-service/views/RejectionTrackerView.swift
+++ b/d2d-map-service/views/RejectionTrackerView.swift
@@ -1,0 +1,38 @@
+//
+//  RejectionTrackerView.swift
+//  d2d-map-service
+//
+//  Created by Emin Okic on 7/4/25.
+//
+import SwiftUI
+
+struct RejectionTrackerView: View {
+    let count: Int
+
+    var body: some View {
+        Button(action: {
+            // Optional: show a popup, detail view, etc.
+        }) {
+            HStack(spacing: 12) {
+                Image(systemName: "xmark.circle")
+                    .foregroundColor(.red)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Total Rejections")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text("\(count)")
+                        .font(.title2)
+                        .bold()
+                        .foregroundColor(.primary)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(.ultraThinMaterial)
+            .cornerRadius(16)
+            .shadow(radius: 4)
+        }
+        .buttonStyle(.plain)
+        // The frame is only applied to the button content; no padding outside
+    }
+}


### PR DESCRIPTION
This PR lets users track rejections since their last sale because that will help door to door reps stay motivated as they push through no's. The tracker resets once a sale is made. This PR also makes the map screen UI look cleaner and more functional for the d2d sales rep. 