### PR TITLE
Implementing Touch & Go Prospecting Feature - July 2025 Release

### DIFF
--- a/d2d-prospecting-service/MapSearchView.swift
+++ b/d2d-prospecting-service/MapSearchView.swift
@@ -245,66 +245,18 @@ struct MapSearchView: View {
             }
         }
         .sheet(isPresented: $showNoteInput) {
-            NavigationView {
-                Form {
-                    Section(header: Text("Note Details")) {
-                        TextEditor(text: $newNoteText)
-                            .frame(minHeight: 100)
-                            .padding(.vertical, 4)
+            if let prospect = prospectToNote {
+                LogNoteView(
+                    prospect: prospect,
+                    objection: selectedObjection,
+                    pendingAddress: pendingAddress,
+                    onComplete: {
+                        followUpAddress = prospect.address
+                        followUpProspectName = prospect.fullName
+                        selectedObjection = nil
+                        showFollowUpPrompt = true
                     }
-                    Section {
-                        Button("Save Note") {
-                            if let prospect = prospectToNote {
-                                let noteContent: String
-
-                                if let objection = selectedObjection {
-                                    noteContent = """
-                                    Not Enough Interest: \(objection.text)
-
-                                    \(newNoteText)
-                                    """
-                                } else if let addr = pendingAddress,
-                                          prospect.knockHistory.last?.status == "Not Answered" {
-                                    noteContent = """
-                                    No Answer
-
-                                    \(newNoteText)
-                                    """
-                                } else {
-                                    noteContent = newNoteText
-                                }
-
-                                let note = Note(content: noteContent)
-                                prospect.notes.append(note)
-                                try? modelContext.save()
-
-                                // Prepare for follow-up
-                                followUpAddress = prospect.address
-                                followUpProspectName = prospect.fullName
-                            }
-
-                            // Reset state
-                            newNoteText = ""
-                            selectedObjection = nil
-                            showNoteInput = false
-
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                                showFollowUpPrompt = true
-                            }
-                        }
-                        .disabled(newNoteText.trimmingCharacters(in: .whitespaces).isEmpty)
-                        .disabled(newNoteText.trimmingCharacters(in: .whitespaces).isEmpty)
-                    }
-                }
-                .navigationTitle("New Note")
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") {
-                            newNoteText = ""
-                            showNoteInput = false
-                        }
-                    }
-                }
+                )
             }
         }
         .onChange(of: showFollowUpSheet) { isShowing in

--- a/d2d-prospecting-service/controllers/MapTapAddressManager.swift
+++ b/d2d-prospecting-service/controllers/MapTapAddressManager.swift
@@ -1,0 +1,36 @@
+//
+//  MapTapAddressManager.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 7/11/25.
+//
+import Foundation
+import MapKit
+import CoreLocation
+
+class MapTapAddressManager: ObservableObject {
+    @Published var tappedAddress: String = ""
+    @Published var tappedCoordinate: CLLocationCoordinate2D?
+    @Published var showAddPrompt: Bool = false
+
+    func handleTap(at coordinate: CLLocationCoordinate2D) {
+        tappedCoordinate = coordinate
+        reverseGeocode(coordinate)
+    }
+
+    private func reverseGeocode(_ coordinate: CLLocationCoordinate2D) {
+        let location = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        CLGeocoder().reverseGeocodeLocation(location) { [weak self] placemarks, error in
+            guard let self = self else { return }
+            if let placemark = placemarks?.first {
+                let addr = [placemark.subThoroughfare,
+                            placemark.thoroughfare,
+                            placemark.locality].compactMap { $0 }.joined(separator: " ")
+                DispatchQueue.main.async {
+                    self.tappedAddress = addr
+                    self.showAddPrompt = true
+                }
+            }
+        }
+    }
+}

--- a/d2d-prospecting-service/views/LogNoteView.swift
+++ b/d2d-prospecting-service/views/LogNoteView.swift
@@ -1,0 +1,66 @@
+//
+//  AddNoteView.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 7/11/25.
+//
+
+
+// Views/AddNoteView.swift
+import SwiftUI
+import SwiftData
+
+struct LogNoteView: View {
+    @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+
+    let prospect: Prospect
+    let objection: Objection?
+    let pendingAddress: String?
+    let onComplete: () -> Void
+
+    @State private var noteText: String = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Note Details")) {
+                    TextEditor(text: $noteText)
+                        .frame(minHeight: 100)
+                }
+
+                Section {
+                    Button("Save Note") {
+                        var fullNote = ""
+
+                        if let obj = objection {
+                            fullNote = "Not Enough Interest: \(obj.text)\n\n\(noteText)"
+                            obj.timesHeard += 1
+                        } else if let addr = pendingAddress,
+                                  prospect.knockHistory.last?.status == "Not Answered" {
+                            fullNote = "No Answer\n\n\(noteText)"
+                        } else {
+                            fullNote = noteText
+                        }
+
+                        prospect.notes.append(Note(content: fullNote))
+                        try? context.save()
+
+                        noteText = ""
+                        dismiss()
+                        onComplete()
+                    }
+                    .disabled(noteText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            .navigationTitle("New Note")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR lets users tap the screen to add prospects. As a d2d sales rep, this makes lives easier because now the prospecting screen can add prospects, log activities, log trips, and pretty much do everything. Letting the crm screen act more as a customer research center. Bonus points because this came from feedback during my customer interview.