### PR TITLE
Implementing A Customer Satisfaction Collection System - July 2025 Release

### DIFF
--- a/d2d-prospecting-service/views/SignUpPopupView.swift
+++ b/d2d-prospecting-service/views/SignUpPopupView.swift
@@ -7,6 +7,9 @@
 import SwiftUI
 import SwiftData
 
+import StoreKit
+
+
 struct SignUpPopupView: View {
     @Bindable var prospect: Prospect
     @Binding var isPresented: Bool
@@ -40,6 +43,16 @@ struct SignUpPopupView: View {
                         prospect.contactEmail = tempEmail
                         try? modelContext.save()
                         isPresented = false
+
+                        // Ask for review only if not already done
+                        if !UserDefaults.standard.hasLeftReview {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                                if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+                                    SKStoreReviewController.requestReview(in: scene)
+                                    UserDefaults.standard.hasLeftReview = true
+                                }
+                            }
+                        }
                     }
                     .disabled(prospect.fullName.isEmpty || prospect.address.isEmpty)
                 }

--- a/d2d-studio/controllers/AppReviewController.swift
+++ b/d2d-studio/controllers/AppReviewController.swift
@@ -1,0 +1,19 @@
+//
+//  AppReviewController.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 7/11/25.
+//
+
+import Foundation
+
+extension UserDefaults {
+    private enum Keys {
+        static let hasLeftReview = "hasLeftReview"
+    }
+
+    var hasLeftReview: Bool {
+        get { bool(forKey: Keys.hasLeftReview) }
+        set { set(newValue, forKey: Keys.hasLeftReview) }
+    }
+}


### PR DESCRIPTION
This PR asks users for a review after each sign up if they haven't given one because that's the peak of the customer value cycle and if they're not happy then, they won't be happy later. Bonus points because this is a feature I got from doing a customer interview