### PR TITLE
Improving Usability Of Follow Up Assistant Screen - July 2025 Release

### DIFF
--- a/d2d-follow-up-service/FollowUpAssistantView.swift
+++ b/d2d-follow-up-service/FollowUpAssistantView.swift
@@ -72,7 +72,7 @@ struct FollowUpAssistantView: View {
                         // Appointments Scorecards
                         HStack(spacing: 12) {
                             LeaderboardCardView(title: "Appointments Today", count: appointmentsToday)
-                            LeaderboardCardView(title: "Appointments This Week", count: appointmentsThisWeek)
+
                             Button {
                                 showTripsSheet = true
                             } label: {

--- a/d2d-follow-up-service/FollowUpAssistantView.swift
+++ b/d2d-follow-up-service/FollowUpAssistantView.swift
@@ -19,6 +19,8 @@ struct FollowUpAssistantView: View {
     
     @Query private var appointments: [Appointment]
     
+    @State private var showTripsSheet = false
+    
     private var appointmentsToday: Int {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
@@ -71,7 +73,12 @@ struct FollowUpAssistantView: View {
                         HStack(spacing: 12) {
                             LeaderboardCardView(title: "Appointments Today", count: appointmentsToday)
                             LeaderboardCardView(title: "Appointments This Week", count: appointmentsThisWeek)
-                            LeaderboardCardView(title: "Trips Made This Week", count: totalTrips)
+                            Button {
+                                showTripsSheet = true
+                            } label: {
+                                LeaderboardCardView(title: "Trips Made This Week", count: totalTrips)
+                            }
+                            .buttonStyle(.plain) // So it looks like a card, not a button
                         }
                     }
                     .padding(.horizontal, 20)
@@ -80,10 +87,6 @@ struct FollowUpAssistantView: View {
                     
                     NavigationView {
                         AppointmentsSectionView()
-                    }
-                    
-                    NavigationView {
-                        TripsSectionView()
                     }
 
                     Spacer()
@@ -109,6 +112,20 @@ struct FollowUpAssistantView: View {
             }
             .fullScreenCover(isPresented: $showActivityOnboarding) {
                 OnboardingFlowView(isPresented: $showActivityOnboarding)
+            }
+            .sheet(isPresented: $showTripsSheet) {
+                NavigationView {
+                    TripsSectionView()
+                        .navigationTitle("Trips")
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Done") {
+                                    showTripsSheet = false
+                                }
+                            }
+                        }
+                }
             }
         }
     }

--- a/d2d-follow-up-service/FollowUpAssistantView.swift
+++ b/d2d-follow-up-service/FollowUpAssistantView.swift
@@ -21,6 +21,8 @@ struct FollowUpAssistantView: View {
     
     @State private var showTripsSheet = false
     
+    @State private var showTodaysAppointmentsSheet = false
+    
     private var appointmentsToday: Int {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
@@ -71,7 +73,12 @@ struct FollowUpAssistantView: View {
                     VStack(spacing: 12) {
                         // Appointments Scorecards
                         HStack(spacing: 12) {
-                            LeaderboardCardView(title: "Appointments Today", count: appointmentsToday)
+                            Button {
+                                showTodaysAppointmentsSheet = true
+                            } label: {
+                                LeaderboardCardView(title: "Appointments Today", count: appointmentsToday)
+                            }
+                            .buttonStyle(.plain)
 
                             Button {
                                 showTripsSheet = true
@@ -122,6 +129,20 @@ struct FollowUpAssistantView: View {
                             ToolbarItem(placement: .cancellationAction) {
                                 Button("Done") {
                                     showTripsSheet = false
+                                }
+                            }
+                        }
+                }
+            }
+            .sheet(isPresented: $showTodaysAppointmentsSheet) {
+                NavigationStack {
+                    TodaysAppointmentsView()
+                        .navigationTitle("Today's Appointments")
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Done") {
+                                    showTodaysAppointmentsSheet = false
                                 }
                             }
                         }

--- a/d2d-follow-up-service/FollowUpAssistantView.swift
+++ b/d2d-follow-up-service/FollowUpAssistantView.swift
@@ -96,9 +96,8 @@ struct FollowUpAssistantView: View {
                         AppointmentsSectionView()
                     }
 
-                    Spacer()
                 }
-                .padding(.bottom, 40)
+                .padding(.bottom, 20)
             }
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)

--- a/d2d-follow-up-service/views/TodaysAppointmentsView.swift
+++ b/d2d-follow-up-service/views/TodaysAppointmentsView.swift
@@ -1,0 +1,47 @@
+//
+//  TodaysAppointmentsView.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 7/13/25.
+//
+
+
+import SwiftUI
+import SwiftData
+
+struct TodaysAppointmentsView: View {
+    @Query private var appointments: [Appointment]
+    @State private var selectedAppointment: Appointment?
+
+    private var todaysAppointments: [Appointment] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        return appointments.filter { calendar.isDate($0.date, inSameDayAs: today) }
+            .sorted { $0.date < $1.date }
+    }
+
+    var body: some View {
+        List {
+            if todaysAppointments.isEmpty {
+                Text("No appointments scheduled for today.")
+                    .foregroundColor(.gray)
+            } else {
+                ForEach(todaysAppointments) { appt in
+                    Button {
+                        selectedAppointment = appt
+                    } label: {
+                        VStack(alignment: .leading) {
+                            Text(appt.title)
+                                .font(.headline)
+                            Text(appt.date.formatted(date: .abbreviated, time: .shortened))
+                                .font(.subheadline)
+                        }
+                    }
+                }
+            }
+        }
+        .sheet(item: $selectedAppointment) { appt in
+            CancelAppointmentView(appointment: appt)
+        }
+    }
+}


### PR DESCRIPTION
This PR makes the trips manager pop up after you click total trips. I remove weekly trips scorecard since I have all appointments at the bottom. Todays appts show todays appt.