### PR TITLE
Improving The Usability Of The Knocking Screen - July 2025 Release

### DIFF
--- a/d2d-prospecting-service/MapSearchView.swift
+++ b/d2d-prospecting-service/MapSearchView.swift
@@ -260,7 +260,7 @@ struct MapSearchView: View {
                         }
                     }
                     .padding(.trailing, 20)
-                    .padding(.bottom, 20) // 
+                    .padding(.bottom, 20)
                 }
 
                 SearchBarView(

--- a/d2d-prospecting-service/MapSearchView.swift
+++ b/d2d-prospecting-service/MapSearchView.swift
@@ -229,14 +229,40 @@ struct MapSearchView: View {
                 Spacer()
             }
 
+            // Scorecard at top right
             ScorecardBar(
                 totalKnocks: totalKnocks,
                 avgKnocksPerSale: averageKnocksPerCustomer,
                 hasSignedUp: hasSignedUp
             )
 
-            VStack(spacing: 0) {
+            // Search bar + Zoom buttons at bottom
+            VStack {
                 Spacer()
+                HStack {
+                    Spacer()
+
+                    VStack(spacing: 10) {
+                        Button(action: { zoom(by: 0.5) }) {
+                            Image(systemName: "plus.magnifyingglass")
+                                .padding()
+                                .background(Color.white)
+                                .clipShape(Circle())
+                                .shadow(radius: 3)
+                        }
+
+                        Button(action: { zoom(by: 2.0) }) {
+                            Image(systemName: "minus.magnifyingglass")
+                                .padding()
+                                .background(Color.white)
+                                .clipShape(Circle())
+                                .shadow(radius: 3)
+                        }
+                    }
+                    .padding(.trailing, 20)
+                    .padding(.bottom, 20) // 
+                }
+
                 SearchBarView(
                     searchText: $searchText,
                     isFocused: $isSearchFocused,
@@ -246,6 +272,13 @@ struct MapSearchView: View {
                 )
             }
         }
+    }
+    
+    private func zoom(by factor: Double) {
+        let currentSpan = controller.region.span
+        let newSpan = MKCoordinateSpan(latitudeDelta: currentSpan.latitudeDelta * factor,
+                                       longitudeDelta: currentSpan.longitudeDelta * factor)
+        controller.region = MKCoordinateRegion(center: controller.region.center, span: newSpan)
     }
     
     private func handleMapCenterChange(newAddress: String?) {

--- a/d2d-prospecting-service/MapSearchView.swift
+++ b/d2d-prospecting-service/MapSearchView.swift
@@ -211,9 +211,8 @@ struct MapSearchView: View {
                         pendingAddress = place.address
                         showOutcomePrompt = true
                     },
-                    onMapTapped: {
-                        let center = controller.region.center
-                        tapManager.handleTap(at: center)
+                    onMapTapped: { coordinate in
+                        tapManager.handleTap(at: coordinate)
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
                             let tapped = tapManager.tappedAddress
                             if !tapped.isEmpty {

--- a/d2d-prospecting-service/views/KnockTutorialView.swift
+++ b/d2d-prospecting-service/views/KnockTutorialView.swift
@@ -1,0 +1,48 @@
+//
+//  KnockTutorialView.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 7/18/25.
+//
+
+
+import SwiftUI
+
+struct KnockTutorialView: View {
+    let totalKnocks: Int
+    let onDismiss: () -> Void
+
+    var body: some View {
+        Color.black.opacity(0.6)
+            .ignoresSafeArea()
+
+        VStack(spacing: 16) {
+            Spacer()
+
+            RejectionTrackerView(count: totalKnocks)
+                .scaleEffect(1.1)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(Color.yellow, lineWidth: 3)
+                )
+
+            Text("This is your knock counter. Every door matters.\nWatch it grow with every interaction.")
+                .multilineTextAlignment(.center)
+                .foregroundColor(.white)
+                .padding()
+                .background(.ultraThinMaterial)
+                .cornerRadius(12)
+                .padding(.horizontal)
+
+            Button("Got it!") {
+                onDismiss()
+            }
+            .padding()
+            .background(Color.white)
+            .foregroundColor(.blue)
+            .cornerRadius(10)
+            .padding(.bottom, 40)
+        }
+        .transition(.scale)
+    }
+}

--- a/d2d-prospecting-service/views/MapDisplayView.swift
+++ b/d2d-prospecting-service/views/MapDisplayView.swift
@@ -1,0 +1,31 @@
+//
+//  MapDisplayView.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 7/18/25.
+//
+import SwiftUI
+import MapKit
+import CoreLocation
+import SwiftData
+import Combine
+import Contacts
+
+struct MapDisplayView: View {
+    @Binding var region: MKCoordinateRegion
+    var markers: [IdentifiablePlace]
+    var onMarkerTapped: (IdentifiablePlace) -> Void
+    var onMapTapped: () -> Void
+
+    var body: some View {
+        Map(coordinateRegion: $region, annotationItems: markers) { place in
+            MapAnnotation(coordinate: place.location) {
+                MarkerView(place: place)
+                    .onTapGesture {
+                        onMarkerTapped(place)
+                    }
+            }
+        }
+        .gesture(TapGesture().onEnded { onMapTapped() })
+    }
+}

--- a/d2d-prospecting-service/views/MapDisplayView.swift
+++ b/d2d-prospecting-service/views/MapDisplayView.swift
@@ -6,26 +6,113 @@
 //
 import SwiftUI
 import MapKit
-import CoreLocation
-import SwiftData
-import Combine
-import Contacts
 
-struct MapDisplayView: View {
+struct MapDisplayView: UIViewRepresentable {
     @Binding var region: MKCoordinateRegion
     var markers: [IdentifiablePlace]
     var onMarkerTapped: (IdentifiablePlace) -> Void
-    var onMapTapped: () -> Void
+    var onMapTapped: (CLLocationCoordinate2D) -> Void
 
-    var body: some View {
-        Map(coordinateRegion: $region, annotationItems: markers) { place in
-            MapAnnotation(coordinate: place.location) {
-                MarkerView(place: place)
-                    .onTapGesture {
-                        onMarkerTapped(place)
-                    }
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onMarkerTapped: onMarkerTapped, onMapTapped: onMapTapped)
+    }
+
+    func makeUIView(context: Context) -> MKMapView {
+        let mapView = MKMapView()
+        mapView.delegate = context.coordinator
+        mapView.setRegion(region, animated: false)
+
+        let tapGesture = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+        mapView.addGestureRecognizer(tapGesture)
+
+        return mapView
+    }
+
+    func updateUIView(_ mapView: MKMapView, context: Context) {
+        mapView.setRegion(region, animated: false)
+        mapView.removeAnnotations(mapView.annotations)
+
+        for place in markers {
+            let annotation = IdentifiableAnnotation(place: place)
+            mapView.addAnnotation(annotation)
+        }
+    }
+
+    class Coordinator: NSObject, MKMapViewDelegate {
+        var onMarkerTapped: (IdentifiablePlace) -> Void
+        var onMapTapped: (CLLocationCoordinate2D) -> Void
+
+        init(onMarkerTapped: @escaping (IdentifiablePlace) -> Void,
+             onMapTapped: @escaping (CLLocationCoordinate2D) -> Void) {
+            self.onMarkerTapped = onMarkerTapped
+            self.onMapTapped = onMapTapped
+        }
+
+        @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+            guard let mapView = gesture.view as? MKMapView else { return }
+
+            let point = gesture.location(in: mapView)
+            let coordinate = mapView.convert(point, toCoordinateFrom: mapView)
+
+            // Ensure tap isn't on a marker
+            let tappedAnnotations = mapView.annotations(in: mapView.visibleMapRect).filter {
+                let viewPoint = mapView.convert(($0 as! MKAnnotation).coordinate, toPointTo: mapView)
+                return hypot(viewPoint.x - point.x, viewPoint.y - point.y) < 30
+            }
+
+            if tappedAnnotations.isEmpty {
+                onMapTapped(coordinate)
             }
         }
-        .gesture(TapGesture().onEnded { onMapTapped() })
+
+        func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+            guard let annotation = annotation as? IdentifiableAnnotation else { return nil }
+
+            let identifier = "customMarker"
+            var view = mapView.dequeueReusableAnnotationView(withIdentifier: identifier)
+
+            if view == nil {
+                view = MKAnnotationView(annotation: annotation, reuseIdentifier: identifier)
+                view?.canShowCallout = false
+            } else {
+                view?.annotation = annotation
+            }
+
+            view?.frame = CGRect(x: 0, y: 0, width: 28, height: 28)
+            view?.layer.cornerRadius = 14
+            view?.backgroundColor = UIColor(annotation.place.markerColor)
+
+            // Custom icon if customer
+            if annotation.place.list == "Customers" {
+                view?.image = UIImage(systemName: "star.circle.fill")?.withTintColor(.systemBlue, renderingMode: .alwaysOriginal)
+            } else {
+                view?.image = nil
+                view?.backgroundColor = UIColor(annotation.place.markerColor)
+            }
+
+            return view
+        }
+
+        func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+            if let annotation = view.annotation as? IdentifiableAnnotation {
+                onMarkerTapped(annotation.place)
+            }
+        }
+    }
+}
+
+private class IdentifiableAnnotation: NSObject, MKAnnotation {
+    let place: IdentifiablePlace
+
+    var coordinate: CLLocationCoordinate2D {
+        place.location
+    }
+
+    var title: String? {
+        place.address
+    }
+
+    init(place: IdentifiablePlace) {
+        self.place = place
     }
 }

--- a/d2d-prospecting-service/views/MarkerView.swift
+++ b/d2d-prospecting-service/views/MarkerView.swift
@@ -1,0 +1,32 @@
+//
+//  MarkerView.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 7/18/25.
+//
+import SwiftUI
+import MapKit
+import CoreLocation
+import SwiftData
+import Combine
+import Contacts
+
+struct MarkerView: View {
+    let place: IdentifiablePlace
+
+    var body: some View {
+        Group {
+            if place.list == "Customers" {
+                Image(systemName: "star.circle.fill")
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                    .foregroundColor(.blue)
+            } else {
+                Circle()
+                    .fill(place.markerColor)
+                    .frame(width: 20, height: 20)
+                    .overlay(Circle().stroke(Color.black, lineWidth: 1))
+            }
+        }
+    }
+}

--- a/d2d-prospecting-service/views/ScorecardBar.swift
+++ b/d2d-prospecting-service/views/ScorecardBar.swift
@@ -1,0 +1,28 @@
+//
+//  ScorecardBar.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 7/18/25.
+//
+import SwiftUI
+
+struct ScorecardBar: View {
+    let totalKnocks: Int
+    let avgKnocksPerSale: Int
+    let hasSignedUp: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            RejectionTrackerView(count: totalKnocks)
+
+            if hasSignedUp {
+                KnocksPerSaleView(count: avgKnocksPerSale, hasFirstSignup: true)
+            }
+        }
+        .cornerRadius(16)
+        .shadow(radius: 4)
+        .padding(.top, 10)
+        .frame(maxWidth: .infinity, alignment: .center)
+        .zIndex(1)
+    }
+}

--- a/d2d-prospecting-service/views/SearchBarView.swift
+++ b/d2d-prospecting-service/views/SearchBarView.swift
@@ -1,0 +1,96 @@
+//
+//  SearchBarView.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 7/18/25.
+//
+import SwiftUI
+import MapKit
+import CoreLocation
+import SwiftData
+import Combine
+import Contacts
+
+struct SearchBarView: View {
+    @Binding var searchText: String
+    @FocusState.Binding var isFocused: Bool
+    @ObservedObject var viewModel: SearchCompleterViewModel
+    var onSubmit: () -> Void
+    var onSelectResult: (MKLocalSearchCompletion) -> Void
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.gray)
+
+                TextField("Enter a knock here…", text: $searchText, onCommit: {
+                    onSubmit()
+                })
+                .focused($isFocused)
+                .foregroundColor(.primary)
+                .autocapitalization(.words)
+                .submitLabel(.done)
+
+                if !searchText.trimmingCharacters(in: .whitespaces).isEmpty {
+                    Button("Done") {
+                        onSubmit()
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(Color.blue.opacity(0.8))
+                    .foregroundColor(.white)
+                    .cornerRadius(8)
+                    .transition(.opacity)
+                }
+            }
+            .padding(12)
+            .background(.ultraThinMaterial)
+            .cornerRadius(12)
+            .shadow(radius: 3, x: 0, y: 2)
+            .padding(.horizontal)
+
+            if isFocused && !viewModel.results.isEmpty {
+                VStack(spacing: 0) {
+                    ForEach(viewModel.results.prefix(3), id: \.self) { result in
+                        Button {
+                            onSelectResult(result)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(result.title)
+                                    .font(.body)
+                                    .bold()
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+
+                                Text(result.subtitle)
+                                    .font(.subheadline)
+                                    .foregroundColor(.gray)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                            }
+                            .padding(.vertical, 10)
+                            .padding(.horizontal)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.white)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+
+                        Divider()
+                    }
+                }
+                .background(Color.white)
+                .cornerRadius(12)
+                .padding(.horizontal)
+                .padding(.top, 4)
+                .shadow(radius: 4)
+                .frame(maxWidth: .infinity)
+                .frame(maxHeight: 180)
+                .transition(.opacity)
+                .zIndex(10)
+            }
+        }
+        .padding(.bottom, 56)
+        .animation(.easeInOut(duration: 0.25), value: viewModel.results.count)
+    }
+}

--- a/d2d-rolodex-service/views/EditProspectView.swift
+++ b/d2d-rolodex-service/views/EditProspectView.swift
@@ -117,7 +117,7 @@ struct EditProspectView: View {
             if prospect.list == "Customers" {
                 Section {
 
-                    Button("Delete Prospect 🗑️") {
+                    Button("Delete Customer 🗑️") {
                         deleteProspect()
                     }
                     .foregroundColor(.red)


### PR DESCRIPTION
This PR improves the usability of the knocking screen by a lot. 
- Customers have different knock prompts than prospects
- Tapping on different parts of the screen asks to add different addresses
- Theres a zoom in and zoom out feature
- Removed the option to add prospects because its redundant
- Improved the UI of markers for customers and prospects