### PR TITLE
Implementing A Prospect Details Popup In The Prospecting Screen - July 2025 Release

### DIFF
--- a/d2d-prospecting-service/views/MapDisplayView.swift
+++ b/d2d-prospecting-service/views/MapDisplayView.swift
@@ -12,6 +12,8 @@ struct MapDisplayView: UIViewRepresentable {
     var markers: [IdentifiablePlace]
     var onMarkerTapped: (IdentifiablePlace) -> Void
     var onMapTapped: (CLLocationCoordinate2D) -> Void
+    
+    static var cachedMapView: MKMapView?
 
     func makeCoordinator() -> Coordinator {
         Coordinator(onMarkerTapped: onMarkerTapped, onMapTapped: onMapTapped)
@@ -24,6 +26,7 @@ struct MapDisplayView: UIViewRepresentable {
         mapView.isZoomEnabled = true
         mapView.isScrollEnabled = true
         mapView.showsUserLocation = false
+        MapDisplayView.cachedMapView = mapView
 
         let tapGesture = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
         mapView.addGestureRecognizer(tapGesture)

--- a/d2d-prospecting-service/views/ProspectPopupView.swift
+++ b/d2d-prospecting-service/views/ProspectPopupView.swift
@@ -1,0 +1,56 @@
+//
+//  ProspectPopupView.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 7/26/25.
+//
+import SwiftUI
+import MapKit
+
+struct ProspectPopupView: View {
+    let place: IdentifiablePlace
+    var onLogKnock: () -> Void
+    var onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Spacer()
+                Button(action: onClose) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.gray)
+                        .imageScale(.large)
+                }
+            }
+
+            Text(place.address)
+                .font(.headline)
+                .multilineTextAlignment(.leading)
+
+            Text("Name: \(findProspectName(for: place.address))")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            Button(action: onLogKnock) {
+                Text("Log Knock")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+            .padding(.top, 8)
+        }
+        .padding()
+        .frame(width: 240)
+        .background(.ultraThinMaterial)
+        .cornerRadius(16)
+        .shadow(radius: 6)
+    }
+
+    func findProspectName(for address: String) -> String {
+        // You can improve this by passing a name directly or querying from outside
+        return "Prospect"
+    }
+}


### PR DESCRIPTION
This PR aims to let users see prospect details from the prospecting screen (formerly known as the map screen). The reason for this is because as a door to door sales rep, I want to be able to do as much from the map screen as I can since the only time I will really use the rolodex and follow up assistant are before i go out and knock in mornings or on weekends. This also improves the usability since it won't ask to log a knock every time you accidentally click the screen which was going to be an issue when you butt dial. 