### PR TITLE
Updating Tab Naming Convention - July 2025 Release

### DIFF
--- a/d2d-studio/views/RootView.swift
+++ b/d2d-studio/views/RootView.swift
@@ -58,14 +58,14 @@ struct RootView: View {
                 }
             )
             .tabItem {
-                Label("CRM", systemImage: "person.3.fill")
+                Label("Contacts", systemImage: "person.3.fill")
             }
             .tag(1)
             
             FollowUpAssistantView(
             )
             .tabItem {
-                Label("Calendar", systemImage: "calendar")
+                Label("Pipeline", systemImage: "calendar")
             }
             .tag(2)
         }


### PR DESCRIPTION
This PR updates the calendar tab into the pipelines tab and I can keep calling it the follow up assistant until the user connects pipelines to follow up assistant.