### PR TITLE
Implementing V4 Of The Search Bar - July 2025 Issue

### DIFF
--- a/d2d-prospecting-service/MapSearchView.swift
+++ b/d2d-prospecting-service/MapSearchView.swift
@@ -155,13 +155,17 @@ struct MapSearchView: View {
                                 viewModel: searchVM,
                                 onSubmit: {
                                     submitSearch()
-                                    searchText = "" // Clear the bar
-                                    withAnimation { isSearchExpanded = false } // Collapse only on submit
+                                    searchText = ""
+                                    withAnimation { isSearchExpanded = false }
                                 },
                                 onSelectResult: {
                                     handleCompletionTap($0)
-                                    // Keep the bar open so user can tap Done/Enter
-                                    // searchText will be replaced by handleCompletionTap anyway
+                                },
+                                onCancel: {
+                                    withAnimation {
+                                        isSearchExpanded = false
+                                        searchText = ""
+                                    }
                                 }
                             )
                             .frame(maxWidth: .infinity, alignment: .trailing)

--- a/d2d-prospecting-service/views/SearchBarView.swift
+++ b/d2d-prospecting-service/views/SearchBarView.swift
@@ -17,9 +17,12 @@ struct SearchBarView: View {
     @ObservedObject var viewModel: SearchCompleterViewModel
     var onSubmit: () -> Void
     var onSelectResult: (MKLocalSearchCompletion) -> Void
+    
+    var onCancel: () -> Void
 
     var body: some View {
         VStack(spacing: 8) {
+            
             HStack {
                 Image(systemName: "magnifyingglass")
                     .foregroundColor(.gray)
@@ -43,6 +46,16 @@ struct SearchBarView: View {
                     .cornerRadius(8)
                     .transition(.opacity)
                 }
+
+                // ⬅️ Add cancel button here
+                Button(action: {
+                    onCancel()
+                }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.gray)
+                        .font(.title3)
+                }
+                .padding(.leading, 6)
             }
             .padding(12)
             .background(.ultraThinMaterial)

--- a/d2d-prospecting-service/views/SearchBarView.swift
+++ b/d2d-prospecting-service/views/SearchBarView.swift
@@ -39,7 +39,7 @@ struct SearchBarView: View {
                     Button("Done") {
                         onSubmit()
                     }
-                    .padding(.horizontal, 8)
+                    .padding(.horizontal, 6)
                     .padding(.vertical, 6)
                     .background(Color.blue.opacity(0.8))
                     .foregroundColor(.white)
@@ -57,9 +57,9 @@ struct SearchBarView: View {
                 }
                 .padding(.leading, 6)
             }
-            .padding(12)
+            .padding(10)
             .background(.ultraThinMaterial)
-            .cornerRadius(12)
+            .cornerRadius(10)
             .shadow(radius: 3, x: 0, y: 2)
             .padding(.horizontal)
 


### PR DESCRIPTION
This PR removes the zoom buttons because it only makes sense when I test on desktop and now that I can sim on my phone, its pointless. The search button expands and collapses now to gives the users more map access and less distractions.