### PR TITLE
Improving The Integration Between The Map Screen & The Rolodex Screen - July 2025 Release

### DIFF
--- a/d2d-rolodex-service/views/CreateSaleView.swift
+++ b/d2d-rolodex-service/views/CreateSaleView.swift
@@ -5,44 +5,12 @@
 //  Created by Emin Okic on 7/21/25.
 //
 import SwiftUI
-import MessageUI
-import Contacts
-import PhoneNumberKit
 
 struct CreateSaleView: View {
-    @Binding var fullName: String
-    @Binding var address: String
-    @Binding var contactPhone: String
-    @Binding var contactEmail: String
-    var onConfirm: () -> Void
-    var onCancel: () -> Void
+    @Bindable var prospect: Prospect
+    @Binding var isPresented: Bool
 
     var body: some View {
-        NavigationView {
-            Form {
-                Section(header: Text("Confirm Customer Info")) {
-                    TextField("Full Name", text: $fullName)
-                    TextField("Address", text: $address)
-                    TextField("Phone", text: $contactPhone)
-                    TextField("Email", text: $contactEmail)
-                }
-
-                Section {
-                    Button("Confirm Sale") {
-                        onConfirm()
-                    }
-                    .disabled(fullName.isEmpty || address.isEmpty)
-                }
-            }
-            .navigationTitle("Create Sale")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        onCancel()
-                    }
-                }
-            }
-        }
+        SignUpPopupView(prospect: prospect, isPresented: $isPresented)
     }
 }

--- a/d2d-rolodex-service/views/ProspectActionsToolbar.swift
+++ b/d2d-rolodex-service/views/ProspectActionsToolbar.swift
@@ -32,6 +32,8 @@ struct ProspectActionsToolbar: View {
     @State private var showExportPrompt = false
     @State private var showExportSuccessBanner = false
     @State private var exportSuccessMessage = ""
+    
+    @EnvironmentObject private var appState: AppState
 
     var body: some View {
         ZStack {
@@ -153,33 +155,7 @@ struct ProspectActionsToolbar: View {
 
         // Create sale sheet
         .sheet(isPresented: $showCreateSaleSheet) {
-            NavigationView {
-                Form {
-                    Section(header: Text("Confirm Customer Info")) {
-                        TextField("Full Name", text: $prospect.fullName)
-                        TextField("Address", text: $prospect.address)
-                        TextField("Phone", text: Binding(
-                            get: { prospect.contactPhone },
-                            set: { prospect.contactPhone = $0 }
-                        ))
-                        TextField("Email", text: Binding(
-                            get: { prospect.contactEmail },
-                            set: { prospect.contactEmail = $0 }
-                        ))
-                    }
-
-                    Section {
-                        Button("Confirm Sale") {
-                            prospect.list = "Customers"
-                            try? modelContext.save()
-                            showCreateSaleSheet = false
-                        }
-                        .disabled(prospect.fullName.isEmpty || prospect.address.isEmpty)
-                    }
-                }
-                .navigationTitle("Create Sale")
-                .navigationBarTitleDisplayMode(.inline)
-            }
+            CreateSaleView(prospect: prospect, isPresented: $showCreateSaleSheet)
         }
 
         // Add phone sheet

--- a/d2d-rolodex-service/views/ProspectDetailsView.swift
+++ b/d2d-rolodex-service/views/ProspectDetailsView.swift
@@ -47,6 +47,8 @@ struct ProspectDetailsView: View {
     @State private var selectedAppointmentDetails: Appointment?
     
     @State private var selectedTab: ProspectTab = .appointments
+    
+    @EnvironmentObject private var appState: AppState
 
     var body: some View {
         Form {
@@ -96,6 +98,7 @@ struct ProspectDetailsView: View {
             
             Section {
                 ProspectActionsToolbar(prospect: prospect)
+                    .environmentObject(appState)
             }
             
             Section {
@@ -201,6 +204,9 @@ struct ProspectDetailsView: View {
                             prospect.contactPhone = tempPhone
                             prospect.contactEmail = tempEmail
                             try? modelContext.save()
+                            
+                            appState.shouldRefreshMapView = true
+                            
                             showConversionSheet = false
                             presentationMode.wrappedValue.dismiss()
                         }

--- a/d2d-studio/models/AppState.swift
+++ b/d2d-studio/models/AppState.swift
@@ -1,0 +1,11 @@
+//
+//  AppState.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 7/31/25.
+//
+import Foundation
+
+class AppState: ObservableObject {
+    @Published var shouldRefreshMapView = false
+}

--- a/d2d-studio/views/RootView.swift
+++ b/d2d-studio/views/RootView.swift
@@ -35,6 +35,8 @@ struct RootView: View {
     @State private var addressToCenter: String? = nil
     
     @State private var searchText: String = ""
+    
+    @StateObject private var appState = AppState()
 
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -44,6 +46,7 @@ struct RootView: View {
                 selectedList: $selectedList,
                 addressToCenter: $addressToCenter
             )
+            .environmentObject(appState)
             .tabItem {
                 Label("Map", systemImage: "map.fill")
             }
@@ -51,12 +54,16 @@ struct RootView: View {
 
             RolodexView(
                 selectedList: $selectedList,
-                onSave: { showingAddProspect = false },
+                onSave: {
+                    appState.shouldRefreshMapView = true
+                    showingAddProspect = false
+                },
                 onDoubleTap: { prospect in
                     selectedTab = 0
                     addressToCenter = prospect.address
                 }
             )
+            .environmentObject(appState)
             .tabItem {
                 Label("Contacts", systemImage: "person.3.fill")
             }


### PR DESCRIPTION
This PR tries to make the integration between the map screen and the rolodex screen smoother. The minimum goal is to at least make it so creating a customer on the prospect details screen reflects those changes on the map screen. Stretch goal if the knocks per sale score card can show. 