### PR TITLE
Moving Toolbar To The Left Side - August 2025 Release

### DIFF
--- a/d2d-prospecting-service/views/FloatingSearchAndMicButtons.swift
+++ b/d2d-prospecting-service/views/FloatingSearchAndMicButtons.swift
@@ -38,8 +38,8 @@ struct FloatingSearchAndMicButtons: View {
             }
         }
         .padding(.bottom, 30)
-        .padding(.trailing, 20)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+        .padding(.leading, 20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         .zIndex(999)
     }
 }

--- a/d2d-rolodex-service/views/ContactsToolbarView.swift
+++ b/d2d-rolodex-service/views/ContactsToolbarView.swift
@@ -24,8 +24,7 @@ struct ContactsToolbarView: View {
             )
 
             if !isSearchExpanded {
-                VStack(spacing: 14) {
-                    
+                VStack(spacing: 10) {
                     Button(action: onAddTapped) {
                         Image(systemName: "plus")
                             .font(.system(size: 24, weight: .bold))
@@ -35,11 +34,11 @@ struct ContactsToolbarView: View {
                             .shadow(radius: 4)
                     }
                     
-                    Spacer().frame(height: 8) // Small gap before search icon (handled by FloatingNameSearchBar)
+                    // Spacer().frame(height: 8)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-                .padding(.bottom, 100) // Offset to sit above search button
-                .padding(.trailing, 20)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+                .padding(.bottom, 110)
+                .padding(.leading, 20)
                 .zIndex(998)
             }
         }

--- a/d2d-search-engine-service/views/FloatingNameSearchBar.swift
+++ b/d2d-search-engine-service/views/FloatingNameSearchBar.swift
@@ -58,7 +58,7 @@ struct FloatingNameSearchBar: View {
                 .cornerRadius(10)
                 .shadow(radius: 3, x: 0, y: 2)
                 .padding(.horizontal)
-                .transition(.move(edge: .trailing).combined(with: .opacity))
+                .transition(.move(edge: .leading).combined(with: .opacity))
 
             } else {
                 Button {
@@ -77,8 +77,8 @@ struct FloatingNameSearchBar: View {
             }
         }
         .padding(.bottom, 30)
-        .padding(.horizontal, 20)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+        .padding(.leading, 20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         .zIndex(999)
     }
 }


### PR DESCRIPTION
This PR makes the toolbar for the map scren and the contacts screen on the left side instead of the right side.