### PR TITLE
Improving The Recentering Feature For The Map Screen - August 2025 Release

### DIFF
--- a/d2d-prospecting-service/MapSearchView.swift
+++ b/d2d-prospecting-service/MapSearchView.swift
@@ -229,10 +229,18 @@ struct MapSearchView: View {
               }
             )
         }
+        .onReceive(NotificationCenter.default.publisher(for: .mapShouldRecenterAllMarkers)) { _ in
+                    controller.recenterToFitAllMarkers()
+                }
         .onChange(of: searchText) { searchVM.updateQuery($0) }
         .onAppear {
             updateMarkers()
             knockController = KnockActionController(modelContext: modelContext, controller: controller)
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    NotificationCenter.default.post(name: .mapShouldRecenterAllMarkers, object: nil)
+                }
+            
         }
         .onChange(of: prospects) { _ in updateMarkers() }
         .onChange(of: selectedList) { _ in updateMarkers() }

--- a/d2d-prospecting-service/controllers/MapController.swift
+++ b/d2d-prospecting-service/controllers/MapController.swift
@@ -64,10 +64,14 @@ class MapController: ObservableObject {
                     )
                     self.markers.append(newPlace)
                 }
-                self.updateRegionToFitAllMarkers()
+                // self.updateRegionToFitAllMarkers()
             }
         }
     }
+    
+    func recenterToFitAllMarkers() {
+            updateRegionToFitAllMarkers()
+        }
     
     /// Updates the `region` property to fit all current markers on the map.
     private func updateRegionToFitAllMarkers() {
@@ -133,7 +137,7 @@ class MapController: ObservableObject {
                     list: list
                 )
                 self.markers.append(newPlace)
-                self.updateRegionToFitAllMarkers()
+                // self.updateRegionToFitAllMarkers()
             }
         }
     }

--- a/d2d-studio/views/RootView.swift
+++ b/d2d-studio/views/RootView.swift
@@ -69,5 +69,18 @@ struct RootView: View {
             }
             .tag(2)
         }
+        .onChange(of: selectedTab) { newValue in
+                    if newValue == 0 {
+                        NotificationCenter.default.post(
+                            name: .mapShouldRecenterAllMarkers,
+                            object: nil
+                        )
+                    }
+                }
+        
     }
+}
+
+extension Notification.Name {
+    static let mapShouldRecenterAllMarkers = Notification.Name("MapShouldRecenterAllMarkers")
 }


### PR DESCRIPTION
This PR makes knocking easier by only recentering the map on app refreshes or tab exits. 