### PR TITLE
Renaming The Count Property In The Contact Management System - DVO 2025 Release

### DIFF
--- a/d2d-activity-management-service/controllers/KnockActionController.swift
+++ b/d2d-activity-management-service/controllers/KnockActionController.swift
@@ -98,7 +98,7 @@ class KnockActionController {
         if let existing = prospects.first(where: {
             $0.address.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) == normalized
         }) {
-            existing.count += 1
+            existing.knockCount += 1
             existing.knockHistory.append(Knock(date: now, status: status, latitude: lat, longitude: lon))
             updated = existing
         } else {

--- a/d2d-contact-management-service/models/ContactProtocol.swift
+++ b/d2d-contact-management-service/models/ContactProtocol.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol ContactProtocol {
     var fullName: String { get set }
     var address: String { get set }
-    var count: Int { get set }
+    var knockCount: Int { get set }
     var contactEmail: String { get set }
     var contactPhone: String { get set }
     var notes: [Note] { get set }

--- a/d2d-customer-management-service/models/Customer.swift
+++ b/d2d-customer-management-service/models/Customer.swift
@@ -12,7 +12,7 @@ import SwiftData
 final class Customer: ContactProtocol {
     var fullName: String
     var address: String
-    var count: Int
+    var knockCount: Int
     var contactEmail: String
     var contactPhone: String
     var notes: [Note]
@@ -24,7 +24,7 @@ final class Customer: ContactProtocol {
          count: Int = 0) {
         self.fullName = fullName
         self.address = address
-        self.count = count
+        self.knockCount = count
         self.contactEmail = ""
         self.contactPhone = ""
         self.notes = []
@@ -38,7 +38,7 @@ extension Customer {
         let customer = Customer(
             fullName: prospect.fullName,
             address: prospect.address,
-            count: prospect.count
+            count: prospect.knockCount
         )
         customer.contactPhone = prospect.contactPhone
         customer.contactEmail = prospect.contactEmail

--- a/d2d-prospect-management-service/models/Prospect.swift
+++ b/d2d-prospect-management-service/models/Prospect.swift
@@ -12,7 +12,7 @@ import SwiftData
 final class Prospect: ContactProtocol {
     var fullName: String
     var address: String
-    var count: Int
+    var knockCount: Int
     var contactEmail: String
     var contactPhone: String
     var notes: [Note]
@@ -28,7 +28,7 @@ final class Prospect: ContactProtocol {
          list: String = "Prospects") {
         self.fullName = fullName
         self.address = address
-        self.count = count
+        self.knockCount = count
         self.list = list
         self.contactEmail = ""
         self.contactPhone = ""

--- a/d2d-prospect-management-service/views/ProspectActionsToolbar.swift
+++ b/d2d-prospect-management-service/views/ProspectActionsToolbar.swift
@@ -310,7 +310,7 @@ struct ProspectActionsToolbar: View {
         }
 
         // ✅ Create Customer record
-        let customer = Customer(fullName: prospect.fullName, address: prospect.address, count: prospect.count)
+        let customer = Customer(fullName: prospect.fullName, address: prospect.address, count: prospect.knockCount)
         customer.contactEmail = prospect.contactEmail
         customer.contactPhone = prospect.contactPhone
         customer.notes = clonedNotes

--- a/d2d-territory-management-service/controllers/MapController.swift
+++ b/d2d-territory-management-service/controllers/MapController.swift
@@ -112,8 +112,8 @@ class MapController: ObservableObject {
         clearMarkers()
         
         let all: [(String, Int, String)] =
-            prospects.map { ($0.address, $0.count, $0.list) } +
-            customers.map { ($0.address, $0.count, "Customers") }
+            prospects.map { ($0.address, $0.knockCount, $0.list) } +
+            customers.map { ($0.address, $0.knockCount, "Customers") }
 
         for (address, count, list) in all {
             geocodeAndAdd(address: address, count: count, list: list)


### PR DESCRIPTION
Count did not make sense so I renamed it to knockCount. 

I could technically use knockHistory's size to count the number of knocks but having to compute that on demand would be bad for biz.