### PR TITLE
Fixing the sale button on the prospect actions toolbar - DVO 2025 Release

### DIFF
--- a/d2d-prospect-management-service/views/ProspectActionsToolbar.swift
+++ b/d2d-prospect-management-service/views/ProspectActionsToolbar.swift
@@ -324,9 +324,9 @@ struct ProspectActionsToolbar: View {
         }
 
         // ✅ Create Customer record
-        let customer = Customer(fullName: prospect.fullName, address: prospect.address, count: prospect.knockCount)
-        customer.contactEmail = prospect.contactEmail
-        customer.contactPhone = prospect.contactPhone
+        let customer = Customer.fromProspect(prospect)
+
+        // overwrite with cloned data (safe)
         customer.notes = clonedNotes
         customer.knockHistory = clonedKnocks
 


### PR DESCRIPTION
This PR fixes the customer conversion form in the prospect actions toolbar because it was outdated. Now it makes markers on the map screen accordingly. 