### PR TITLE
Implementing an email validation service - JVO 2026 Release

### DIFF
--- a/d2d-contact-export-service/controllers/EmailDomainPolicy.swift
+++ b/d2d-contact-export-service/controllers/EmailDomainPolicy.swift
@@ -1,0 +1,22 @@
+//
+//  EmailDomainPolicy.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 1/5/26.
+//
+
+struct EmailDomainPolicy {
+    static let blockedDomains: Set<String> = [
+        "mailinator.com",
+        "tempmail.com",
+        "10minutemail.com",
+        "guerrillamail.com"
+    ]
+
+    static func isAllowedDomain(_ email: String) -> Bool {
+        guard let domain = email.split(separator: "@").last else {
+            return false
+        }
+        return !blockedDomains.contains(domain.lowercased())
+    }
+}

--- a/d2d-contact-export-service/controllers/EmailValidator.swift
+++ b/d2d-contact-export-service/controllers/EmailValidator.swift
@@ -1,0 +1,25 @@
+//
+//  EmailValidator.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 1/5/26.
+//
+
+
+struct EmailValidator {
+    static func validate(_ email: String) -> EmailValidationError? {
+        if !isValidFormat(email) {
+            return .invalidFormat
+        }
+        if !EmailDomainPolicy.isAllowedDomain(email) {
+            return .blockedDomain
+        }
+        return nil
+    }
+
+    private static func isValidFormat(_ email: String) -> Bool {
+        let pattern =
+        #"^[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"#
+        return email.range(of: pattern, options: .regularExpression) != nil
+    }
+}

--- a/d2d-contact-export-service/models/EmailValidationError.swift
+++ b/d2d-contact-export-service/models/EmailValidationError.swift
@@ -1,0 +1,12 @@
+//
+//  EmailValidationError.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 1/5/26.
+//
+
+
+enum EmailValidationError: String {
+    case invalidFormat = "Please enter a valid email address"
+    case blockedDomain = "Please use a non-disposable email domain"
+}

--- a/d2d-contact-export-service/views/ExportEmailGateView.swift
+++ b/d2d-contact-export-service/views/ExportEmailGateView.swift
@@ -85,12 +85,15 @@ struct ExportEmailGateView: View {
     }
 
     private func handleUnlock() {
+        
         let trimmed = email.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.contains("@") else {
+        
+        if let error = EmailValidator.validate(trimmed) {
             showError = true
+            // Optional: store error.rawValue to display a specific message
             return
         }
-
+        
         showError = false
         EmailGateManager.shared.unlock(with: trimmed)
 


### PR DESCRIPTION
This update strengthens the export sign-up funnel by introducing proper email verification to prevent spam and low-quality data from entering the contact syncing service. Email validation has been centralized into a dedicated validator that enforces correct email formatting and blocks disposable or known spam domains before access is granted, replacing the previous minimal “@” check. This ensures only legitimate, well-formed email addresses can unlock CSV exports while keeping the experience fast and fully client-side. The result is a cleaner dataset, improved abuse protection, and a more robust foundation for future server-side or third-party email verification if stricter enforcement is needed later.