### PR TITLE
Implementing A New Mutli Unit Feature For The Map Screen (Pt. I) - JVO 2026 Release

### DIFF
--- a/d2d-territory-management-service/controllers/MapController.swift
+++ b/d2d-territory-management-service/controllers/MapController.swift
@@ -114,18 +114,16 @@ class MapController: ObservableObject {
         
         var grouped: [String: [UnitContact]] = [:]
 
-        // 🔹 Collect PROSPECT units
+        // Collect PROSPECTs
         for p in prospects {
             guard let coord = p.coordinate else { continue }
-
             let base = parseAddress(p.address).base
             grouped[base, default: []].append(.prospect(p))
         }
 
-        // 🔹 Collect CUSTOMER units
+        // Collect CUSTOMERS
         for c in customers {
             guard let coord = c.coordinate else { continue }
-
             let base = parseAddress(c.address).base
             grouped[base, default: []].append(.customer(c))
         }
@@ -133,9 +131,9 @@ class MapController: ObservableObject {
         for (base, units) in grouped {
             guard let coord = units.first?.coordinate else { continue }
 
-            let isMultiUnit = units.count > 1
+            // 🔹 Determine if it's a true multi-unit (Unit 1, Unit 2, etc.)
+            let isMultiUnit = units.contains { parseAddress($0.address).unit != nil }
 
-            // Marker "role" rules
             let hasCustomer = units.contains { $0.isCustomer }
             let hasUnqualified = units.contains { $0.isUnqualified }
 
@@ -143,7 +141,6 @@ class MapController: ObservableObject {
             let isUnqualified = !hasCustomer && hasUnqualified
 
             let totalKnocks = units.reduce(0) { $0 + $1.knockCount }
-            
             let unitCount = units.count
 
             markers.append(
@@ -154,7 +151,7 @@ class MapController: ObservableObject {
                     unitCount: unitCount,
                     list: list,
                     isUnqualified: isUnqualified,
-                    isMultiUnit: isMultiUnit
+                    isMultiUnit: isMultiUnit // TRUE only if real "Unit X"
                 )
             )
         }

--- a/d2d-territory-management-service/views/MapDisplayCoordinator.swift
+++ b/d2d-territory-management-service/views/MapDisplayCoordinator.swift
@@ -410,17 +410,37 @@ final class MapDisplayCoordinator: NSObject, MKMapViewDelegate {
     }
 
     private func standardMarkerView(for annotation: IdentifiableAnnotation) -> MKAnnotationView {
-
         let id = "customMarker"
-
-        let view =
-            mapView?.dequeueReusableAnnotationView(withIdentifier: id)
+        let view = mapView?.dequeueReusableAnnotationView(withIdentifier: id)
             ?? MKAnnotationView(annotation: annotation, reuseIdentifier: id)
 
         view.annotation = annotation
         view.canShowCallout = false
 
         configure(view, for: annotation)
+
+        // 🔢 Show badge if multiple contacts at same address (normal marker)
+        if !annotation.place.isMultiUnit && annotation.place.unitCount > 1 {
+            let badgeSize: CGFloat = 16
+
+            let badge = UILabel()
+            badge.text = "\(annotation.place.unitCount)"
+            badge.textColor = .white
+            badge.font = .boldSystemFont(ofSize: 10)
+            badge.textAlignment = .center
+            badge.backgroundColor = .systemBlue
+            badge.layer.cornerRadius = badgeSize / 2
+            badge.layer.masksToBounds = true
+
+            badge.frame = CGRect(
+                x: view.bounds.maxX - badgeSize + 2,
+                y: -2,
+                width: badgeSize,
+                height: badgeSize
+            )
+
+            view.addSubview(badge)
+        }
 
         return view
     }

--- a/d2d-territory-management-service/views/UnitSelectorPopupView.swift
+++ b/d2d-territory-management-service/views/UnitSelectorPopupView.swift
@@ -37,7 +37,7 @@ struct UnitSelectorPopupView: View {
                             onSelect(unit)
                         } label: {
                             HStack {
-                                Text(unitLabel(for: unit.address))
+                                Text(unitLabel(for: unit))
                                     .font(.headline)
 
                                 if unit.isUnqualified {
@@ -79,7 +79,17 @@ struct UnitSelectorPopupView: View {
         .shadow(radius: 8)
     }
 
-    private func unitLabel(for address: String) -> String {
-        parseAddress(address).unit.map { "Unit \($0)" } ?? "Main"
+    private func unitLabel(for unit: UnitContact) -> String {
+        if let unitNumber = parseAddress(unit.address).unit {
+            return "Unit \(unitNumber)"
+        } else {
+            // Use the Prospect/Customer fullName
+            switch unit {
+            case .prospect(let p):
+                return p.fullName
+            case .customer(let c):
+                return c.fullName
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR extends the map display functionality to properly handle cases where multiple contacts exist at the same address, specifically for multi-unit properties. When a marker representing a multi-unit address is tapped, the coordinator now checks for all units associated with that address. If multiple units are present, it triggers the onShowUnitPopup callback, providing a list of all individual units so the user can select or interact with each one separately. For single-unit cases, the standard marker tap behavior is preserved. This enhancement ensures that multi-unit properties are represented accurately on the map, improving usability and clarity when managing multiple contacts at the same location.