### PR TITLE
Fixing The Map Controller Tests - JVO 2026 Release

### DIFF
--- a/d2d-studioTests/MapControllerTests.swift
+++ b/d2d-studioTests/MapControllerTests.swift
@@ -69,7 +69,7 @@ final class MapControllerTests: XCTestCase {
         XCTAssertNotNil(customerMarker)
 
         XCTAssertEqual(customerMarker?.count, 0)
-        XCTAssertEqual(customerMarker?.unitCount, 1)
+        XCTAssertEqual(customerMarker?.unitCount, 0)
         XCTAssertFalse(customerMarker?.isMultiUnit ?? true)
     }
 


### PR DESCRIPTION
In the case there is a customer and prospect at the same address but different units, the unit count for 456 Main St Unit 2 should still be 0 unless there are multiple contacts at a single unit.

Technically a unit count would be 2 for 456 Main St but 0 for 456 Main St Unit 1 and 456 Main St Unit 2.