### PR TITLE
Implementing A Map Refresh For Customer Actions On The Map Screen - JVO 2026 Release

### DIFF
--- a/d2d-territory-management-service/MapSearchView.swift
+++ b/d2d-territory-management-service/MapSearchView.swift
@@ -236,6 +236,7 @@ struct MapSearchView: View {
             
             // This is for the prospect updating marker stuff
             .onChange(of: prospects) { _ in updateMarkers() }
+            .onChange(of: customers) { _ in updateMarkers() }
             .onChange(of: selectedList) { _ in updateMarkers() }
             
             // Prospect Popup Stuff

--- a/d2d-territory-management-service/controllers/MapController.swift
+++ b/d2d-territory-management-service/controllers/MapController.swift
@@ -30,6 +30,73 @@ class MapController: ObservableObject {
         self.region = region
     }
     
+    /// Replaces existing markers with those derived from the provided list of prospects.
+    /// - Parameter prospects: Array of `Prospect` objects to display.
+    func setMarkers(prospects: [Prospect], customers: [Customer]) {
+        
+        clearMarkers()
+        
+        var groups: [String: AddressGroup] = [:]
+        
+        for p in prospects {
+            let parsed = parseAddress(p.address)
+            groups[parsed.base, default: AddressGroup(base: parsed.base, units: [:])]
+                .units[parsed.unit, default: []]
+                .append(.prospect(p))
+        }
+        
+        for c in customers {
+            let parsed = parseAddress(c.address)
+            groups[parsed.base, default: AddressGroup(base: parsed.base, units: [:])]
+                .units[parsed.unit, default: []]
+                .append(.customer(c))
+        }
+        
+        for (_, group) in groups {
+            let base = group.base
+            let unitsDict = group.units
+            
+            // Pick any contact to get a coordinate
+            guard let firstContact = unitsDict.values.first?.first,
+                  let coord = firstContact.coordinate else { continue }
+            
+            // ---- Step 2: Decide marker type ----
+            let contactCount = unitsDict.values.reduce(0) { $0 + $1.count }
+            
+            let unitKeys = unitsDict.keys.compactMap { $0 }
+            
+            let unitCount = Set(unitKeys).count
+            
+            let isMultiUnit = unitCount > 1
+            
+            let showsMultiContact = (!isMultiUnit && contactCount > 1)
+            
+            let hasCustomer = unitsDict.values.flatMap { $0 }.contains { $0.isCustomer }
+            let hasUnqualified = unitsDict.values.flatMap { $0 }.contains { $0.isUnqualified }
+            
+            let list = hasCustomer ? "Customers" : "Prospects"
+            let isUnqualified = !hasCustomer && hasUnqualified
+            
+            let totalKnocks = unitsDict.values
+                .flatMap { $0 }
+                .reduce(0) { $0 + $1.knockCount }
+            
+            markers.append(
+                IdentifiablePlace(
+                    address: base,
+                    location: coord,
+                    count: totalKnocks,
+                    unitCount: unitCount,
+                    contactCount: contactCount,
+                    list: list,
+                    isUnqualified: isUnqualified,
+                    isMultiUnit: isMultiUnit,
+                    showsMultiContact: showsMultiContact
+                )
+            )
+        }
+    }
+    
     /// Clears all existing markers from the map.
     func clearMarkers() {
         markers.removeAll()
@@ -103,73 +170,6 @@ class MapController: ObservableObject {
     func addProspects(_ prospects: [Prospect]) {
         for prospect in prospects {
             performSearch(query: prospect.address)
-        }
-    }
-    
-    /// Replaces existing markers with those derived from the provided list of prospects.
-    /// - Parameter prospects: Array of `Prospect` objects to display.
-    func setMarkers(prospects: [Prospect], customers: [Customer]) {
-        
-        clearMarkers()
-        
-        var groups: [String: AddressGroup] = [:]
-        
-        for p in prospects {
-            let parsed = parseAddress(p.address)
-            groups[parsed.base, default: AddressGroup(base: parsed.base, units: [:])]
-                .units[parsed.unit, default: []]
-                .append(.prospect(p))
-        }
-        
-        for c in customers {
-            let parsed = parseAddress(c.address)
-            groups[parsed.base, default: AddressGroup(base: parsed.base, units: [:])]
-                .units[parsed.unit, default: []]
-                .append(.customer(c))
-        }
-        
-        for (_, group) in groups {
-            let base = group.base
-            let unitsDict = group.units
-            
-            // Pick any contact to get a coordinate
-            guard let firstContact = unitsDict.values.first?.first,
-                  let coord = firstContact.coordinate else { continue }
-            
-            // ---- Step 2: Decide marker type ----
-            let contactCount = unitsDict.values.reduce(0) { $0 + $1.count }
-            
-            let unitKeys = unitsDict.keys.compactMap { $0 }
-            
-            let unitCount = Set(unitKeys).count
-            
-            let isMultiUnit = unitCount > 1
-            
-            let showsMultiContact = (!isMultiUnit && contactCount > 1)
-            
-            let hasCustomer = unitsDict.values.flatMap { $0 }.contains { $0.isCustomer }
-            let hasUnqualified = unitsDict.values.flatMap { $0 }.contains { $0.isUnqualified }
-            
-            let list = hasCustomer ? "Customers" : "Prospects"
-            let isUnqualified = !hasCustomer && hasUnqualified
-            
-            let totalKnocks = unitsDict.values
-                .flatMap { $0 }
-                .reduce(0) { $0 + $1.knockCount }
-            
-            markers.append(
-                IdentifiablePlace(
-                    address: base,
-                    location: coord,
-                    count: totalKnocks,
-                    unitCount: unitCount,
-                    contactCount: contactCount,
-                    list: list,
-                    isUnqualified: isUnqualified,
-                    isMultiUnit: isMultiUnit,
-                    showsMultiContact: showsMultiContact
-                )
-            )
         }
     }
     


### PR DESCRIPTION
Customer management just got tighter and more reliable. When you delete a customer, their marker now disappears from the map instantly—no more “ghost” pins hanging around after a cleanup. The map stays perfectly in sync with your data, so what you see is always what actually exists. Fewer surprises, faster feedback, and a smoother flow when you’re managing your territory.