### PR TITLE
Updating The Exit Button On The Prospect/Customer Details Page - JVO 2026 Release

### DIFF
--- a/d2d-customer-details-management-service/CustomerDetailsView.swift
+++ b/d2d-customer-details-management-service/CustomerDetailsView.swift
@@ -188,15 +188,7 @@ struct CustomerDetailsView: View {
                     presentationMode.wrappedValue.dismiss()
                     
                 } label: {
-                    ZStack {
-                        Circle()
-                            .fill(Color.red)
-
-                        Image(systemName: "xmark")
-                            .font(.system(size: 14, weight: .bold))
-                            .foregroundColor(.white)
-                    }
-
+                    Label("Back", systemImage: "chevron.left")
                 }
                 .buttonStyle(.plain)
             }

--- a/d2d-prospect-details-management-service/ProspectDetailsView.swift
+++ b/d2d-prospect-details-management-service/ProspectDetailsView.swift
@@ -164,15 +164,7 @@ struct ProspectDetailsView: View {
                     presentationMode.wrappedValue.dismiss()
                     
                 } label: {
-                    ZStack {
-                        Circle()
-                            .fill(Color.red)
-
-                        Image(systemName: "xmark")
-                            .font(.system(size: 14, weight: .bold))
-                            .foregroundColor(.white)
-                    }
-
+                    Label("Back", systemImage: "chevron.left")
                 }
                 .buttonStyle(.plain)
             }


### PR DESCRIPTION
Updating the back button on the prospect and customer details page to match the apple ios close sheet button.