### PR TITLE
Fixing The Duplicate Contact Issue For Scheduling Appointments - JVO 2026 Release

### DIFF
--- a/d2d-customer-details-management-service/views/ScheduleCustomerAppointmentView.swift
+++ b/d2d-customer-details-management-service/views/ScheduleCustomerAppointmentView.swift
@@ -14,7 +14,7 @@ struct ScheduleCustomerAppointmentView: View {
 
     let customer: Customer
 
-    @State private var title = "Follow-Up"
+    @State private var title = "Follow-Up "
     @State private var location = ""
     @State private var clientName = ""
     @State private var date = Date()
@@ -80,7 +80,7 @@ struct ScheduleCustomerAppointmentView: View {
                         FollowUpScreenSoundController.shared.playSound1()
 
                         let appointment = Appointment(
-                            title: title,
+                            title: "\(customer.fullName)",
                             location: location,
                             clientName: clientName,
                             date: date,

--- a/d2d-follow-up-service/FollowUpAssistantView.swift
+++ b/d2d-follow-up-service/FollowUpAssistantView.swift
@@ -74,6 +74,8 @@ struct FollowUpAssistantView: View {
     @Binding var deepLinkFilter: AppointmentFilter?
     
     @Query private var customers: [Customer]
+    
+    @State private var selectedCustomer: Customer?
 
     var body: some View {
         NavigationView {
@@ -171,7 +173,9 @@ struct FollowUpAssistantView: View {
             .sheet(isPresented: $showAppointmentsPicker) {
                 ContactPickerView(
                     contacts: prospects as [any ContactProtocol] + customers as [any ContactProtocol],
-                    selectedProspect: $selectedProspect
+                    prospects: prospects,
+                    selectedProspect: $selectedProspect,
+                    selectedCustomer: $selectedCustomer
                 )
             }
             .alert("Delete selected appointments?", isPresented: $showDeleteAppointmentsConfirm) {
@@ -244,12 +248,17 @@ struct FollowUpAssistantView: View {
             .sheet(isPresented: $showingProspectPicker) {
                 ContactPickerView(
                     contacts: prospects as [any ContactProtocol] + customers as [any ContactProtocol],
-                    selectedProspect: $selectedProspect
+                    prospects: prospects,
+                    selectedProspect: $selectedProspect,
+                    selectedCustomer: $selectedCustomer
                 )
             }
             .sheet(item: $selectedProspect) { p in
                 // You can pass a default date if you like
                 ScheduleAppointmentView(prospect: p)
+            }
+            .sheet(item: $selectedCustomer) { c in
+                ScheduleCustomerAppointmentView(customer: c)
             }
 
             // NEW: Recordings sheet

--- a/d2d-follow-up-service/views/ContactPickerView.swift
+++ b/d2d-follow-up-service/views/ContactPickerView.swift
@@ -10,6 +10,8 @@ import SwiftData
 
 struct ContactPickerView: View {
     let contacts: [any ContactProtocol]   // now supports both Prospect & Customer
+    let prospects: [Prospect]
+    
     @Binding var selectedProspect: Prospect?
     @Environment(\.dismiss) private var dismiss
     var title: String = "Pick Contact"
@@ -23,6 +25,8 @@ struct ContactPickerView: View {
             $0.address.localizedCaseInsensitiveContains(searchText)
         }
     }
+    
+    @Binding var selectedCustomer: Customer?
 
     var body: some View {
         NavigationStack {
@@ -51,16 +55,22 @@ struct ContactPickerView: View {
                                 
                                 if let prospect = contact as? Prospect {
                                     selectedProspect = prospect
-                                } else if let customer = contact as? Customer {
-                                    // Convert customer to Prospect if needed or handle differently
-                                    let tempProspect = Prospect(
-                                        fullName: customer.fullName,
-                                        address: customer.address,
-                                        count: customer.knockCount
-                                    )
-                                    selectedProspect = tempProspect
+                                    selectedCustomer = nil
+                                }
+                                else if let customer = contact as? Customer {
+                                    if let match = prospects.first(where: {
+                                        $0.address == customer.address &&
+                                        $0.fullName == customer.fullName
+                                    }) {
+                                        selectedProspect = match
+                                        selectedCustomer = nil
+                                    } else {
+                                        selectedProspect = nil
+                                        selectedCustomer = customer   // 👈 open customer scheduler
+                                    }
                                 }
                                 dismiss()
+                                
                             } label: {
                                 HStack {
                                     VStack(alignment: .leading, spacing: 2) {


### PR DESCRIPTION
We fixed an issue where scheduled appointments were sometimes showing titles like “Follow-Up With Follow-Up” instead of using the client’s name. Appointment titles now reliably auto-fill as “Follow-Up With [Client Name]” for both prospects and customers. This ensures every follow-up is clearly labeled and easier to recognize at a glance.