### PR TITLE
Implementing An In App Purchase To Remove Ads (Pt. II) - June 26 Feature Release

### DIFF
--- a/StoreKit.storekit
+++ b/StoreKit.storekit
@@ -1,0 +1,54 @@
+{
+  "appPolicies" : {
+    "eula" : "",
+    "policies" : [
+      {
+        "locale" : "en_US",
+        "policyText" : "",
+        "policyURL" : ""
+      }
+    ]
+  },
+  "identifier" : "418E8B61",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+    {
+      "displayPrice" : "0.69",
+      "familyShareable" : false,
+      "internalID" : "F2074206",
+      "localizations" : [
+        {
+          "description" : "",
+          "displayName" : "",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.d2dstudio.removeads",
+      "referenceName" : "Remove Ads",
+      "type" : "NonConsumable"
+    }
+  ],
+  "settings" : {
+    "_askToBuyEnabled" : false,
+    "_billingGracePeriodEnabled" : false,
+    "_billingIssuesEnabled" : false,
+    "_disableDialogs" : false,
+    "_failTransactionsEnabled" : false,
+    "_locale" : "en_US",
+    "_renewalBillingIssuesEnabled" : false,
+    "_storefront" : "USA",
+    "_storeKitErrors" : [
+
+    ],
+    "_timeRate" : 0
+  },
+  "subscriptionGroups" : [
+
+  ],
+  "version" : {
+    "major" : 5,
+    "minor" : 0
+  }
+}

--- a/d2d-ad-engine-service/controllers/AdEngine.swift
+++ b/d2d-ad-engine-service/controllers/AdEngine.swift
@@ -8,10 +8,13 @@
 import Foundation
 import Combine
 import UIKit
+import StoreKit
 
 @MainActor
 public final class AdEngine: ObservableObject {
+    
     public static let shared = AdEngine()
+    
     private init() {}
 
     @Published public private(set) var currentAd: Ad?
@@ -20,9 +23,66 @@ public final class AdEngine: ObservableObject {
 
     // Session gate: once closed (X or click), don't show again until next app launch
     private var sessionClosed = false
+    
+    @Published var adsRemoved = false
+    
+    private let removeAdsProductID = "com.d2dstudio.removeads"
+    
+    func loadPurchases() async {
+
+        for await result in Transaction.currentEntitlements {
+
+            guard case .verified(let transaction) = result else {
+
+                continue
+
+            }
+
+            if transaction.productID == removeAdsProductID {
+
+                adsRemoved = true
+
+                currentAd = nil
+
+            }
+
+        }
+
+    }
+    
+    func purchaseRemoveAds() async {
+        guard let product = try? await Product.products(
+            for: [removeAdsProductID]
+        ).first else {
+            return
+        }
+
+        let result = try? await product.purchase()
+
+        guard
+            case .success(let verification) = result,
+            case .verified(let transaction) = verification
+        else {
+            return
+        }
+
+        adsRemoved = true
+        currentAd = nil
+
+        await transaction.finish()
+    }
 
     // ===== NEW: one-shot startup API (no rotation) =====
     public func startSingleShot(inventory: [Ad]) {
+        
+        guard !adsRemoved else {
+
+            currentAd = nil
+
+            return
+
+        }
+        
         guard !sessionClosed else { return } // already dismissed/clicked this session
         self.inventory = inventory
 

--- a/d2d-ad-engine-service/views/AdImagePopupView.swift
+++ b/d2d-ad-engine-service/views/AdImagePopupView.swift
@@ -21,9 +21,11 @@ public struct AdImagePopupView: View {
 
     public var body: some View {
         ZStack(alignment: .topTrailing) {
-            VStack(spacing: 0) {
+
+            VStack(spacing: 12) {
                 if let imageName = ad.imageName {
                     let tapAll = ad.tapEntireImage ?? true
+
                     Image(imageName)
                         .resizable()
                         .scaledToFit()
@@ -37,7 +39,27 @@ public struct AdImagePopupView: View {
                             openURL(ad.destination)
                         }
                 } else {
-                    AdPopupView(ad: ad, onDismiss: onDismiss, onClick: onClick)
+                    AdPopupView(
+                        ad: ad,
+                        onDismiss: onDismiss,
+                        onClick: onClick
+                    )
+                }
+
+                // 👇 Remove Ads button appears below the ad
+                if !AdEngine.shared.adsRemoved {
+                    Button {
+                        Task {
+                            await AdEngine.shared.purchaseRemoveAds()
+                        }
+                    } label: {
+                        Label("$0.69", systemImage: "sparkles")
+                            .font(.footnote.weight(.semibold))
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 8)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .clipShape(Capsule())
                 }
             }
 

--- a/d2d-ad-engine-service/views/AdImagePopupView.swift
+++ b/d2d-ad-engine-service/views/AdImagePopupView.swift
@@ -48,19 +48,13 @@ public struct AdImagePopupView: View {
 
                 // 👇 Remove Ads button appears below the ad
                 if !AdEngine.shared.adsRemoved {
-                    Button {
+                    RemoveAdsCTAView(isLoading: false) {
                         Task {
                             await AdEngine.shared.purchaseRemoveAds()
                         }
-                    } label: {
-                        Label("$0.69", systemImage: "sparkles")
-                            .font(.footnote.weight(.semibold))
-                            .padding(.horizontal, 14)
-                            .padding(.vertical, 8)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .clipShape(Capsule())
                 }
+                
             }
 
             // ✅ White X with depth (inner stroke + shadow) for light/white backgrounds

--- a/d2d-ad-engine-service/views/RemoveAdsCTAView.swift
+++ b/d2d-ad-engine-service/views/RemoveAdsCTAView.swift
@@ -1,0 +1,66 @@
+//
+//  RemoveAdsCTAView.swift
+//  d2d-studio
+//
+//  Created by Emin Okic on 6/13/26.
+//
+
+import SwiftUI
+
+struct RemoveAdsCTAView: View {
+    let isLoading: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 10) {
+
+                Image(systemName: "sparkles")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .padding(8)
+                    .background(
+                        LinearGradient(
+                            colors: [.purple, .pink],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .clipShape(Circle())
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Remove Ads Forever")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.primary)
+
+                    Text("One-time unlock • $0.69")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if isLoading {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                } else {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color(.secondarySystemBackground))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14)
+                            .stroke(Color.black.opacity(0.06), lineWidth: 1)
+                    )
+                    .shadow(color: .black.opacity(0.05), radius: 10, y: 4)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/d2d-studio.xcodeproj/project.pbxproj
+++ b/d2d-studio.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C50C757C2FDDB7FA00B8080D /* StoreKit.storekit in Resources */ = {isa = PBXBuildFile; fileRef = C50C757B2FDDB7FA00B8080D /* StoreKit.storekit */; };
+		C50C757D2FDDB7FA00B8080D /* StoreKit.storekit in Resources */ = {isa = PBXBuildFile; fileRef = C50C757B2FDDB7FA00B8080D /* StoreKit.storekit */; };
+		C50C757E2FDDB7FA00B8080D /* StoreKit.storekit in Resources */ = {isa = PBXBuildFile; fileRef = C50C757B2FDDB7FA00B8080D /* StoreKit.storekit */; };
 		C53F34042DE9E60900372BEE /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = C53F34032DE9E60900372BEE /* SQLite */; };
 		C5855D892DF073A700B479AE /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = C5855D882DF073A300B479AE /* .gitignore */; };
 		C5B3EE8A2F0B013700732B79 /* d2d-studio-TestPlan.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = C5B3EE892F0B013700732B79 /* d2d-studio-TestPlan.xctestplan */; };
@@ -69,6 +72,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		C50C757B2FDDB7FA00B8080D /* StoreKit.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = StoreKit.storekit; sourceTree = "<group>"; };
 		C54048432DF4B32A00721D49 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		C5855D882DF073A300B479AE /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		C5B3EE7E2F0B002A00732B79 /* d2d-studioTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "d2d-studioTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -255,6 +259,7 @@
 		C5BE4B2B2DE7CC9E005C37B1 = {
 			isa = PBXGroup;
 			children = (
+				C50C757B2FDDB7FA00B8080D /* StoreKit.storekit */,
 				C5B3EE892F0B013700732B79 /* d2d-studio-TestPlan.xctestplan */,
 				C5E6A7362E2BEBCF00EC05F4 /* d2d-widget-serviceExtension.entitlements */,
 				C5CDA5B22E15A65300FD96B7 /* PRIVACYPOLICY.md */,
@@ -456,6 +461,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C50C757E2FDDB7FA00B8080D /* StoreKit.storekit in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -464,6 +470,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5855D892DF073A700B479AE /* .gitignore in Resources */,
+				C50C757C2FDDB7FA00B8080D /* StoreKit.storekit in Resources */,
 				C5B3EE8A2F0B013700732B79 /* d2d-studio-TestPlan.xctestplan in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -472,6 +479,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C50C757D2FDDB7FA00B8080D /* StoreKit.storekit in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/d2d-studio.xcodeproj/xcshareddata/xcschemes/d2d-studio.xcscheme
+++ b/d2d-studio.xcodeproj/xcshareddata/xcschemes/d2d-studio.xcscheme
@@ -55,6 +55,9 @@
             ReferencedContainer = "container:d2d-studio.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <StoreKitConfigurationFileReference
+         identifier = "../../StoreKit.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/d2d-territory-management-service/MapSearchView.swift
+++ b/d2d-territory-management-service/MapSearchView.swift
@@ -352,7 +352,7 @@ struct MapSearchView: View {
             //
             // inside body chain where you had the presenter & lifecycle hooks
             
-            // Add related modifiers
+            // Ad related modifiers
             .presentRotatingAdsCentered()
             .onAppear {
                 // 🔹 Show exactly one ad for this app session (centered). Will differ each launch.
@@ -361,6 +361,14 @@ struct MapSearchView: View {
             .onDisappear {
                 // No-op for single-shot, but keep if you want to explicitly clear.
                 AdEngine.shared.stop()
+            }
+            .onAppear {
+                Task {
+                    await AdEngine.shared.loadPurchases()
+                    AdEngine.shared.startSingleShot(
+                        inventory: AdDemoInventory.defaultAds
+                    )
+                }
             }
             
             // Search engine related modifiers


### PR DESCRIPTION
This PR is meant to implement the first in app purchase for the d2d studio. This will let users remove ads so they can focus on prospecting door to door for only 0.69 cents. Yeah its thats cheap and you dont even need to pay for it.

Now there is two revenue streams where ad affiliates can pay to stream ads and door to door sales reps can pay a small fee to remove ads. 