### PR TITLE
Implementing A Whole New Contact Popup System For The Map Screen - July '26 Release

### DIFF
--- a/d2d-territory-management-service/MapSearchView.swift
+++ b/d2d-territory-management-service/MapSearchView.swift
@@ -66,6 +66,7 @@ struct MapSearchView: View {
     @State private var pendingBulkAdd: PendingBulkAdd?
     
     @State private var selectedUnitGroup: UnitGroup?
+    @State private var selectedMultiContactState: MultiContactState?
     @State private var selectedProspect: Prospect?
     @State private var selectedCustomer: Customer?
     @State private var pendingSelectedContact: UnitContact? = nil
@@ -143,29 +144,29 @@ struct MapSearchView: View {
                 UnitSelectorPopupView(
                     baseAddress: group.base,
                     units: group.units,
-                    onSelect: { unit in
+                    onSelect: { unitGroup in
                         selectedUnitGroup = nil
-
-                        let place = IdentifiablePlace(
-                            address: unit.address,
-                            location: unit.coordinate ?? controller.region.center,
-                            count: unit.knockCount,
-                            unitCount: 1,
-                            contactCount: 1,
-                            list: unit.list,
-                            isUnqualified: unit.isUnqualified,
-                            isMultiUnit: false,
-                            showsMultiContact: false,
-                            selectedContact: unit     // 👈 CRITICAL
-                        )
-
-                        showPopup(for: place)
+                        openUnitContactGroup(unitGroup, baseAddress: group.base)
                     },
                     onClose: {
                         selectedUnitGroup = nil
                     }
                 )
                 .presentationDetents([.fraction(0.46)])
+                .presentationDragIndicator(.visible)
+            }
+            .sheet(item: $selectedMultiContactState) { state in
+                MultiContactPopupView(
+                    state: state,
+                    onSelect: { contact in
+                        selectedMultiContactState = nil
+                        showPopup(for: place(for: contact))
+                    },
+                    onClose: {
+                        selectedMultiContactState = nil
+                    }
+                )
+                .presentationDetents([.fraction(0.42)])
                 .presentationDragIndicator(.visible)
             }
             // This is for the contact popup display
@@ -542,7 +543,7 @@ struct MapSearchView: View {
         
         // 🔹 STEP for Apartment / multi-unit interception
         let parts = parseAddress(place.address)
-        let units = unitsForBaseAddress(parts.base)
+        let units = unitContactGroupsForBaseAddress(parts.base)
 
         if units.count > 1 {
             // ✅ Center map on the apartment complex itself
@@ -552,6 +553,19 @@ struct MapSearchView: View {
             
             // Show unit selector instead of prospect popup
             selectedUnitGroup = UnitGroup(base: parts.base, units: units)
+            return
+        }
+
+        if let unitGroup = units.first, unitGroup.contactCount > 1 {
+            withAnimation(.easeInOut(duration: 0.35)) {
+                controller.centerMapForPopup(coordinate: place.location)
+            }
+
+            selectedMultiContactState = MultiContactState(
+                baseAddress: parts.base,
+                unit: unitGroup.unit,
+                contacts: unitGroup.contacts
+            )
             return
         }
         
@@ -636,6 +650,40 @@ struct MapSearchView: View {
                 coordinator.refreshAllAnnotations(on: mapView)
             }
         }
+    }
+
+    private func openUnitContactGroup(_ unitGroup: UnitContactGroup, baseAddress: String) {
+        if unitGroup.contactCount > 1 {
+            DispatchQueue.main.async {
+                selectedMultiContactState = MultiContactState(
+                    baseAddress: baseAddress,
+                    unit: unitGroup.unit,
+                    contacts: unitGroup.contacts
+                )
+            }
+            return
+        }
+
+        guard let contact = unitGroup.primaryContact else { return }
+
+        DispatchQueue.main.async {
+            showPopup(for: place(for: contact))
+        }
+    }
+
+    private func place(for contact: UnitContact) -> IdentifiablePlace {
+        IdentifiablePlace(
+            address: contact.address,
+            location: contact.coordinate ?? controller.region.center,
+            count: contact.knockCount,
+            unitCount: 1,
+            contactCount: 1,
+            list: contact.list,
+            isUnqualified: contact.isUnqualified,
+            isMultiUnit: false,
+            showsMultiContact: false,
+            selectedContact: contact
+        )
     }
 
     @ViewBuilder
@@ -994,7 +1042,7 @@ struct MapSearchView: View {
         }
     }
     
-    private func unitsForBaseAddress(_ base: String) -> [UnitContact] {
+    private func unitContactGroupsForBaseAddress(_ base: String) -> [UnitContactGroup] {
 
         let prospectUnits = prospects
             .filter {
@@ -1008,7 +1056,42 @@ struct MapSearchView: View {
             }
             .map { UnitContact.customer($0) }
 
-        return prospectUnits + customerUnits
+        let contacts = prospectUnits + customerUnits
+        let grouped = Dictionary(grouping: contacts) { contact in
+            parseAddress(contact.address).unit
+        }
+
+        return grouped
+            .map { unit, contacts in
+                UnitContactGroup(unit: unit, contacts: sortedContacts(contacts))
+            }
+            .sorted { lhs, rhs in
+                unitSortKey(lhs.unit).localizedStandardCompare(unitSortKey(rhs.unit)) == .orderedAscending
+            }
+    }
+
+    private func sortedContacts(_ contacts: [UnitContact]) -> [UnitContact] {
+        contacts.sorted { lhs, rhs in
+            if lhs.isCustomer != rhs.isCustomer {
+                return lhs.isCustomer
+            }
+
+            return contactName(for: lhs).localizedStandardCompare(contactName(for: rhs)) == .orderedAscending
+        }
+    }
+
+    private func unitSortKey(_ unit: String?) -> String {
+        guard let unit else { return "0000" }
+        return unit
+    }
+
+    private func contactName(for contact: UnitContact) -> String {
+        switch contact {
+        case .prospect(let prospect):
+            return prospect.fullName
+        case .customer(let customer):
+            return customer.fullName
+        }
     }
     
     private func saveFollowUp(

--- a/d2d-territory-management-service/MapSearchView.swift
+++ b/d2d-territory-management-service/MapSearchView.swift
@@ -169,30 +169,20 @@ struct MapSearchView: View {
                 .presentationDragIndicator(.visible)
             }
             // This is for the contact popup display
-            .sheet(item: $popupState) { popup in
+            .sheet(item: $popupState, onDismiss: resetSelectedMapMarker) { popup in
                 ProspectPopupView(
                     place: popup.place,
                     isCustomer: popup.place.list == "Customers",
                     onClose: {
                         popupState = nil
-                        selectedPlaceID = nil
-                        
-                        // 🔑 Force MapKit to deselect the annotation
-                        if let mapView = MapDisplayView.cachedMapView {
-                            DispatchQueue.main.async {
-                                mapView.selectedAnnotations.forEach {
-                                    mapView.deselectAnnotation($0, animated: false)
-                                }
-                            }
-                        }
-                        
+                        resetSelectedMapMarker()
                     },
                     onOutcomeSelected: { outcome, fileName in
                         pendingAddress = popup.place.address
                         pendingSelectedContact = popup.place.selectedContact   // 👈 store it
                         isTappedAddressCustomer = popup.place.list == "Customers"
                         popupState = nil
-                        selectedPlaceID = nil
+                        resetSelectedMapMarker()
 
                         if outcome == "Follow Up Later" {
                             pendingRecordingFileName = fileName
@@ -659,6 +649,26 @@ struct MapSearchView: View {
         selectedPlaceID = nil
         pendingAddProperty = PendingAddProperty(address: address, coordinate: coordinate)
         controller.centerMapForNewProperty(coordinate: coordinate)
+    }
+
+    private func resetSelectedMapMarker() {
+        selectedPlaceID = nil
+
+        guard let mapView = MapDisplayView.cachedMapView else { return }
+
+        DispatchQueue.main.async {
+            if let coordinator = mapView.delegate as? MapDisplayCoordinator {
+                coordinator.updateSelectedPlaceID(nil)
+            }
+
+            mapView.selectedAnnotations.forEach {
+                mapView.deselectAnnotation($0, animated: false)
+            }
+
+            if let coordinator = mapView.delegate as? MapDisplayCoordinator {
+                coordinator.refreshAllAnnotations(on: mapView)
+            }
+        }
     }
     
     // For updating the markers

--- a/d2d-territory-management-service/MapSearchView.swift
+++ b/d2d-territory-management-service/MapSearchView.swift
@@ -165,7 +165,7 @@ struct MapSearchView: View {
                         selectedUnitGroup = nil
                     }
                 )
-                .presentationDetents([.fraction(0.5)])
+                .presentationDetents([.fraction(0.46)])
                 .presentationDragIndicator(.visible)
             }
             // This is for the contact popup display

--- a/d2d-territory-management-service/MapSearchView.swift
+++ b/d2d-territory-management-service/MapSearchView.swift
@@ -140,7 +140,7 @@ struct MapSearchView: View {
             .onChange(of: selectedList) { updateMarkers() }
             
             // Prospect Popup Stuff
-            .sheet(item: $selectedUnitGroup) { group in
+            .sheet(item: $selectedUnitGroup, onDismiss: resetSelectedMapMarker) { group in
                 UnitSelectorPopupView(
                     baseAddress: group.base,
                     units: group.units,
@@ -150,12 +150,14 @@ struct MapSearchView: View {
                     },
                     onClose: {
                         selectedUnitGroup = nil
+                        resetSelectedMapMarker()
                     }
                 )
                 .presentationDetents([.fraction(0.46)])
+                .presentationBackgroundInteraction(.enabled(upThrough: .fraction(0.46)))
                 .presentationDragIndicator(.visible)
             }
-            .sheet(item: $selectedMultiContactState) { state in
+            .sheet(item: $selectedMultiContactState, onDismiss: resetSelectedMapMarker) { state in
                 MultiContactPopupView(
                     state: state,
                     onSelect: { contact in
@@ -164,9 +166,11 @@ struct MapSearchView: View {
                     },
                     onClose: {
                         selectedMultiContactState = nil
+                        resetSelectedMapMarker()
                     }
                 )
                 .presentationDetents([.fraction(0.42)])
+                .presentationBackgroundInteraction(.enabled(upThrough: .fraction(0.42)))
                 .presentationDragIndicator(.visible)
             }
             // This is for the contact popup display
@@ -591,6 +595,10 @@ struct MapSearchView: View {
     private func handleMapTap(at coordinate: CLLocationCoordinate2D) {
         // 🎯 Haptic: instant response
         MapScreenHapticsController.shared.mapTap()
+
+        if dismissActiveMapPopup() {
+            return
+        }
         
         // Deselect any currently selected marker
         selectedPlaceID = nil
@@ -652,6 +660,18 @@ struct MapSearchView: View {
         }
     }
 
+    private func dismissActiveMapPopup() -> Bool {
+        guard popupState != nil || selectedUnitGroup != nil || selectedMultiContactState != nil else {
+            return false
+        }
+
+        popupState = nil
+        selectedUnitGroup = nil
+        selectedMultiContactState = nil
+        resetSelectedMapMarker()
+        return true
+    }
+
     private func openUnitContactGroup(_ unitGroup: UnitContactGroup, baseAddress: String) {
         if unitGroup.contactCount > 1 {
             DispatchQueue.main.async {
@@ -711,6 +731,7 @@ struct MapSearchView: View {
             }
         )
         .presentationDetents([.fraction(0.34)])
+        .presentationBackgroundInteraction(.enabled(upThrough: .fraction(0.34)))
         .presentationDragIndicator(.visible)
     }
 
@@ -731,6 +752,7 @@ struct MapSearchView: View {
             }
         )
         .presentationDetents([.fraction(0.5)])
+        .presentationBackgroundInteraction(.enabled(upThrough: .fraction(0.5)))
         .presentationDragIndicator(.visible)
     }
 

--- a/d2d-territory-management-service/MapSearchView.swift
+++ b/d2d-territory-management-service/MapSearchView.swift
@@ -170,40 +170,7 @@ struct MapSearchView: View {
             }
             // This is for the contact popup display
             .sheet(item: $popupState, onDismiss: resetSelectedMapMarker) { popup in
-                ProspectPopupView(
-                    place: popup.place,
-                    isCustomer: popup.place.list == "Customers",
-                    onClose: {
-                        popupState = nil
-                        resetSelectedMapMarker()
-                    },
-                    onOutcomeSelected: { outcome, fileName in
-                        pendingAddress = popup.place.address
-                        pendingSelectedContact = popup.place.selectedContact   // 👈 store it
-                        isTappedAddressCustomer = popup.place.list == "Customers"
-                        popupState = nil
-                        resetSelectedMapMarker()
-
-                        if outcome == "Follow Up Later" {
-                            pendingRecordingFileName = fileName
-                            stepperState = .init(
-                                ctx: .init(
-                                    address: popup.place.address,
-                                    isCustomer: isTappedAddressCustomer,
-                                    prospect: nil
-                                )
-                            )
-                        } else {
-                            handleOutcome(outcome, recordingFileName: fileName)
-                        }
-                    },
-                    recordingModeEnabled: recordingModeEnabled,
-                    onViewDetails: {
-                        openDetails(for: popup.place)
-                    }
-                )
-                .presentationDetents([.fraction(0.5)])
-                .presentationDragIndicator(.visible)
+                popupSheet(for: popup)
             }
             .sheet(item: $stepperState) { state in
                 VStack {
@@ -668,6 +635,75 @@ struct MapSearchView: View {
             if let coordinator = mapView.delegate as? MapDisplayCoordinator {
                 coordinator.refreshAllAnnotations(on: mapView)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func popupSheet(for popup: PopupState) -> some View {
+        if popup.place.list == "Customers" {
+            customerPopupSheet(for: popup.place)
+        } else {
+            prospectPopupSheet(for: popup.place)
+        }
+    }
+
+    private func customerPopupSheet(for place: IdentifiablePlace) -> some View {
+        CustomerPopupView(
+            place: place,
+            onClose: {
+                popupState = nil
+                resetSelectedMapMarker()
+            },
+            onOutcomeSelected: { outcome, fileName in
+                handlePopupOutcome(for: place, outcome: outcome, fileName: fileName)
+            },
+            recordingModeEnabled: recordingModeEnabled,
+            onViewDetails: {
+                openDetails(for: place)
+            }
+        )
+        .presentationDetents([.fraction(0.34)])
+        .presentationDragIndicator(.visible)
+    }
+
+    private func prospectPopupSheet(for place: IdentifiablePlace) -> some View {
+        ProspectPopupView(
+            place: place,
+            isCustomer: false,
+            onClose: {
+                popupState = nil
+                resetSelectedMapMarker()
+            },
+            onOutcomeSelected: { outcome, fileName in
+                handlePopupOutcome(for: place, outcome: outcome, fileName: fileName)
+            },
+            recordingModeEnabled: recordingModeEnabled,
+            onViewDetails: {
+                openDetails(for: place)
+            }
+        )
+        .presentationDetents([.fraction(0.5)])
+        .presentationDragIndicator(.visible)
+    }
+
+    private func handlePopupOutcome(for place: IdentifiablePlace, outcome: String, fileName: String?) {
+        pendingAddress = place.address
+        pendingSelectedContact = place.selectedContact
+        isTappedAddressCustomer = place.list == "Customers"
+        popupState = nil
+        resetSelectedMapMarker()
+
+        if outcome == "Follow Up Later" {
+            pendingRecordingFileName = fileName
+            stepperState = .init(
+                ctx: .init(
+                    address: place.address,
+                    isCustomer: isTappedAddressCustomer,
+                    prospect: nil
+                )
+            )
+        } else {
+            handleOutcome(outcome, recordingFileName: fileName)
         }
     }
     

--- a/d2d-territory-management-service/controllers/MapController.swift
+++ b/d2d-territory-management-service/controllers/MapController.swift
@@ -65,9 +65,7 @@ class MapController: ObservableObject {
             // ---- Step 2: Decide marker type ----
             let contactCount = unitsDict.values.reduce(0) { $0 + $1.count }
             
-            let unitKeys = unitsDict.keys.compactMap { $0 }
-            
-            let unitCount = Set(unitKeys).count
+            let unitCount = unitsDict.keys.count
             
             let isMultiUnit = unitCount > 1
             

--- a/d2d-territory-management-service/models/MultiContactState.swift
+++ b/d2d-territory-management-service/models/MultiContactState.swift
@@ -1,0 +1,13 @@
+//
+//  MultiContactState.swift
+//  d2d-studio
+//
+
+import Foundation
+
+struct MultiContactState: Identifiable {
+    let id = UUID()
+    let baseAddress: String
+    let unit: String?
+    let contacts: [UnitContact]
+}

--- a/d2d-territory-management-service/models/UnitContactGroup.swift
+++ b/d2d-territory-management-service/models/UnitContactGroup.swift
@@ -1,0 +1,35 @@
+//
+//  UnitContactGroup.swift
+//  d2d-studio
+//
+
+import Foundation
+
+struct UnitContactGroup: Identifiable {
+    let unit: String?
+    let contacts: [UnitContact]
+
+    var id: String {
+        unit ?? "main"
+    }
+
+    var contactCount: Int {
+        contacts.count
+    }
+
+    var hasCustomer: Bool {
+        contacts.contains { $0.isCustomer }
+    }
+
+    var hasUnqualified: Bool {
+        contacts.contains { $0.isUnqualified }
+    }
+
+    var knockCount: Int {
+        contacts.reduce(0) { $0 + $1.knockCount }
+    }
+
+    var primaryContact: UnitContact? {
+        contacts.first
+    }
+}

--- a/d2d-territory-management-service/models/UnitGroup.swift
+++ b/d2d-territory-management-service/models/UnitGroup.swift
@@ -9,5 +9,5 @@ import Foundation
 struct UnitGroup: Identifiable {
     let id = UUID()
     let base: String
-    let units: [UnitContact]
+    let units: [UnitContactGroup]
 }

--- a/d2d-territory-management-service/views/CustomerPopupView.swift
+++ b/d2d-territory-management-service/views/CustomerPopupView.swift
@@ -1,0 +1,253 @@
+//
+//  CustomerPopupView.swift
+//  d2d-studio
+//
+
+import SwiftUI
+import SwiftData
+
+struct CustomerPopupView: View {
+    @Query private var customers: [Customer]
+
+    let place: IdentifiablePlace
+    var onClose: () -> Void
+    var onOutcomeSelected: (String, String?) -> Void
+    let recordingModeEnabled: Bool
+    var onViewDetails: () -> Void
+
+    @AppStorage("studioUnlocked") private var studioUnlocked: Bool = false
+    @State private var isRecording = false
+    @State private var currentFileName: String?
+
+    private let recorder = RecordingManager()
+    private var recordingFeaturesActive: Bool { studioUnlocked && recordingModeEnabled }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+            customerRow
+            actionsSection
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 12)
+        .padding(.bottom, 16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Color(.systemGroupedBackground))
+        .onAppear {
+            if recordingFeaturesActive {
+                startRecording()
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color.green.opacity(0.14))
+                    .frame(width: 48, height: 48)
+
+                Image(systemName: "checkmark.seal.fill")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(.green)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Text("Customer")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.green)
+
+                    if isRecording {
+                        Label("Recording", systemImage: "waveform")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.red)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Color.red.opacity(0.1), in: Capsule())
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(formattedAddressLines, id: \.self) { line in
+                        Text(line)
+                            .font(.headline.weight(.bold))
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.82)
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            Button(action: closePopup) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 34, height: 34)
+                    .background(Color(.secondarySystemGroupedBackground), in: Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
+    }
+
+    private var customerRow: some View {
+        Button(action: openCustomerDetails) {
+            HStack(spacing: 12) {
+                Image(systemName: "person.crop.circle.fill.badge.checkmark")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(.green)
+                    .frame(width: 34, height: 34)
+                    .background(Color.green.opacity(0.1), in: Circle())
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(customerName)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+
+                    Text("\(place.count) \(place.count == 1 ? "knock" : "knocks") logged")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(12)
+            .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var actionsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Log Customer Knock")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+
+            HStack(spacing: 8) {
+                actionButton(
+                    systemName: "person.crop.circle.badge.xmark",
+                    label: "Lost",
+                    color: .red
+                ) { stopAndHandleOutcome("Customer Lost") }
+
+                actionButton(
+                    systemName: "house.slash.fill",
+                    label: "Not Home",
+                    color: .gray
+                ) { stopAndHandleOutcome("Wasn't Home") }
+
+                actionButton(
+                    systemName: "calendar.badge.clock",
+                    label: "Follow Up",
+                    color: .orange
+                ) { stopAndHandleOutcome("Follow Up Later") }
+            }
+        }
+    }
+
+    private func actionButton(systemName: String, label: String, color: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 5) {
+                Image(systemName: systemName)
+                    .font(.system(size: 19, weight: .semibold))
+                    .foregroundStyle(color)
+                    .frame(width: 30, height: 30)
+                    .background(color.opacity(0.11), in: Circle())
+
+                Text(label)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 66)
+            .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var formattedAddressLines: [String] {
+        let parts = place.address.components(separatedBy: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+
+        if parts.count >= 3 {
+            let street = parts[0]
+            let city = parts[1]
+            let stateZip = parts[2]
+            return [street, "\(city), \(stateZip)"]
+        }
+
+        let words = place.address.components(separatedBy: " ")
+        if words.count >= 5 {
+            let street = words.prefix(3).joined(separator: " ")
+            let rest = words.dropFirst(3).joined(separator: " ")
+            return [street, rest]
+        }
+
+        return [place.address]
+    }
+
+    private var customerName: String {
+        if case .customer(let customer)? = place.selectedContact {
+            return customer.fullName
+        }
+
+        return customers.first(where: { $0.address == place.address })?.fullName ?? "Customer"
+    }
+
+    private func closePopup() {
+        MapScreenHapticsController.shared.propertyAdded()
+        MapScreenSoundController.shared.playPropertyAdded()
+        onClose()
+    }
+
+    private func openCustomerDetails() {
+        MapScreenHapticsController.shared.propertyAdded()
+        MapScreenSoundController.shared.playPropertyAdded()
+        onViewDetails()
+    }
+
+    private func startRecording() {
+        let result = recorder.start()
+        if result.started {
+            isRecording = true
+            currentFileName = result.fileName
+        }
+    }
+
+    private func stopAndHandleOutcome(_ outcome: String) {
+        MapScreenHapticsController.shared.propertyAdded()
+        MapScreenSoundController.shared.playPropertyAdded()
+
+        recorder.stop()
+        isRecording = false
+
+        if outcome == "Wasn't Home" {
+            discardRecording()
+            onOutcomeSelected(outcome, nil)
+        } else {
+            onOutcomeSelected(outcome, currentFileName)
+        }
+
+        currentFileName = nil
+    }
+
+    private func discardRecording() {
+        if let file = currentFileName {
+            let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent(file)
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+}

--- a/d2d-territory-management-service/views/MapDisplayCoordinator.swift
+++ b/d2d-territory-management-service/views/MapDisplayCoordinator.swift
@@ -353,6 +353,10 @@ final class MapDisplayCoordinator: NSObject, MKMapViewDelegate {
             return buildingMarkerView(for: annotation)
         }
 
+        if annotation.place.showsMultiContact {
+            return multiContactMarkerView(for: annotation)
+        }
+
         // 🔴 If unqualified, use special view
         if annotation.place.isUnqualified {
             return unqualifiedMarkerView(for: annotation)
@@ -544,6 +548,47 @@ final class MapDisplayCoordinator: NSObject, MKMapViewDelegate {
         return view
     }
 
+    private func multiContactMarkerView(for annotation: IdentifiableAnnotation) -> MKAnnotationView {
+        let id = "multiContactMarker"
+        let view = mapView?.dequeueReusableAnnotationView(withIdentifier: id)
+            ?? MKAnnotationView(annotation: annotation, reuseIdentifier: id)
+
+        view.annotation = annotation
+        view.canShowCallout = false
+        configureMultiContactMarker(view, for: annotation)
+
+        return view
+    }
+
+    private func configureMultiContactMarker(_ view: MKAnnotationView, for annotation: IdentifiableAnnotation) {
+        let isSelected = annotation.place.id == selectedPlaceID
+        let size = markerSize(
+            for: annotation.place,
+            isSelected: isSelected,
+            minimumSize: 48,
+            selectedMinimumSize: 74
+        )
+
+        configurePropertyToken(
+            view,
+            for: annotation.place,
+            size: size,
+            isSelected: isSelected,
+            symbolName: "person.2.fill"
+        )
+
+        addBadge(
+            to: view,
+            count: annotation.place.contactCount,
+            color: .systemBlue,
+            size: max(18, size * 0.28)
+        )
+
+        if annotation.place.list == "Customers" {
+            addCustomerStarBadge(to: view, size: max(17, size * 0.25))
+        }
+    }
+
     private func userLocationView(for mapView: MKMapView) -> MKAnnotationView? {
         let id = "userLocation"
         let view = mapView.dequeueReusableAnnotationView(withIdentifier: id)
@@ -718,6 +763,27 @@ final class MapDisplayCoordinator: NSObject, MKMapViewDelegate {
         )
         view.addSubview(badge)
     }
+
+    private func addCustomerStarBadge(to view: MKAnnotationView, size: CGFloat) {
+        let badge = UIImageView(image: UIImage(systemName: "star.fill"))
+        badge.tintColor = .systemYellow
+        badge.contentMode = .scaleAspectFit
+        badge.backgroundColor = .white
+        badge.layer.cornerRadius = size / 2
+        badge.layer.borderWidth = 1.5
+        badge.layer.borderColor = UIColor.systemYellow.withAlphaComponent(0.85).cgColor
+        badge.layer.shadowColor = UIColor.black.cgColor
+        badge.layer.shadowOpacity = 0.16
+        badge.layer.shadowRadius = 3
+        badge.layer.shadowOffset = CGSize(width: 0, height: 1)
+        badge.frame = CGRect(
+            x: view.bounds.maxX - size + 1,
+            y: view.bounds.maxY - size + 1,
+            width: size,
+            height: size
+        )
+        view.addSubview(badge)
+    }
     
     func refreshAllAnnotations(on mapView: MKMapView) {
         for annotation in mapView.annotations {
@@ -887,6 +953,12 @@ final class MapDisplayCoordinator: NSObject, MKMapViewDelegate {
 
         if annotation.place.isMultiUnit {
             configureBuildingMarker(view, for: annotation)
+            return
+        }
+
+        if annotation.place.showsMultiContact {
+            configureMultiContactMarker(view, for: annotation)
+            view.alpha = selectedPlaceID == nil || annotation.place.id == selectedPlaceID ? 1.0 : 0.42
             return
         }
         

--- a/d2d-territory-management-service/views/MultiContactPopupView.swift
+++ b/d2d-territory-management-service/views/MultiContactPopupView.swift
@@ -1,43 +1,36 @@
 //
-//  UnitSelectorPopupView.swift
+//  MultiContactPopupView.swift
 //  d2d-studio
-//
-//  Created by Emin Okic on 12/27/25.
 //
 
 import SwiftUI
 
-struct UnitSelectorPopupView: View {
-    let baseAddress: String
-    let units: [UnitContactGroup]
-    let onSelect: (UnitContactGroup) -> Void
+struct MultiContactPopupView: View {
+    let state: MultiContactState
+    let onSelect: (UnitContact) -> Void
     let onClose: () -> Void
 
-    private var contactCount: Int {
-        units.reduce(0) { $0 + $1.contactCount }
-    }
-
     private var customerCount: Int {
-        units.reduce(0) { total, group in
-            total + group.contacts.filter(\.isCustomer).count
-        }
-    }
-
-    private var unqualifiedCount: Int {
-        units.reduce(0) { total, group in
-            total + group.contacts.filter(\.isUnqualified).count
-        }
+        state.contacts.filter(\.isCustomer).count
     }
 
     private var prospectCount: Int {
-        contactCount - customerCount
+        state.contacts.count - customerCount
+    }
+
+    private var title: String {
+        if let unit = state.unit {
+            return "Unit \(unit)"
+        }
+
+        return "Multiple Contacts"
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             header
             summaryRow
-            unitList
+            contactList
         }
         .padding(.horizontal, 18)
         .padding(.top, 12)
@@ -50,20 +43,20 @@ struct UnitSelectorPopupView: View {
         HStack(alignment: .top, spacing: 12) {
             ZStack {
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(Color.indigo.opacity(0.14))
+                    .fill(Color.blue.opacity(0.14))
                     .frame(width: 48, height: 48)
 
-                Image(systemName: "building.2.fill")
+                Image(systemName: "person.2.fill")
                     .font(.system(size: 22, weight: .semibold))
-                    .foregroundStyle(.indigo)
+                    .foregroundStyle(.blue)
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("Multi-Unit Property")
+                Text(title)
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.indigo)
+                    .foregroundStyle(.blue)
 
-                Text(baseAddress)
+                Text(state.baseAddress)
                     .font(.headline.weight(.bold))
                     .foregroundStyle(.primary)
                     .lineLimit(2)
@@ -85,37 +78,27 @@ struct UnitSelectorPopupView: View {
     }
 
     private var summaryRow: some View {
-            HStack(spacing: 8) {
-                summaryTile(value: "\(units.count)", label: units.count == 1 ? "Unit" : "Units", systemName: "door.left.hand.open", tint: .indigo)
-            summaryTile(value: "\(contactCount)", label: contactCount == 1 ? "Contact" : "Contacts", systemName: "person.2.fill", tint: .blue)
-            summaryTile(value: "\(customerCount)", label: customerCount == 1 ? "Customer" : "Customers", systemName: "checkmark.seal.fill", tint: .green)
+        HStack(spacing: 8) {
+            summaryTile(value: "\(state.contacts.count)", label: state.contacts.count == 1 ? "Contact" : "Contacts", systemName: "person.2.fill", tint: .blue)
+            summaryTile(value: "\(prospectCount)", label: prospectCount == 1 ? "Prospect" : "Prospects", systemName: "person.crop.circle.badge.clock", tint: .indigo)
+            summaryTile(value: "\(customerCount)", label: customerCount == 1 ? "Customer" : "Customers", systemName: "star.fill", tint: .yellow)
         }
     }
 
-    private var unitList: some View {
+    private var contactList: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text("Select Unit")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .textCase(.uppercase)
-
-                Spacer()
-
-                if unqualifiedCount > 0 {
-                    Label("\(unqualifiedCount)", systemImage: "xmark.octagon.fill")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.red)
-                }
-            }
+            Text("Select Contact")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
 
             ScrollView {
                 LazyVStack(spacing: 8) {
-                    ForEach(units) { unit in
+                    ForEach(state.contacts) { contact in
                         Button {
-                            select(unit)
+                            select(contact)
                         } label: {
-                            unitRow(for: unit)
+                            contactRow(for: contact)
                         }
                         .buttonStyle(.plain)
                     }
@@ -126,36 +109,27 @@ struct UnitSelectorPopupView: View {
         }
     }
 
-    private func unitRow(for unit: UnitContactGroup) -> some View {
+    private func contactRow(for contact: UnitContact) -> some View {
         HStack(spacing: 12) {
             ZStack {
                 Circle()
-                    .fill(statusColor(for: unit).opacity(0.12))
+                    .fill(statusColor(for: contact).opacity(0.12))
                     .frame(width: 38, height: 38)
 
-                Image(systemName: statusIcon(for: unit))
+                Image(systemName: statusIcon(for: contact))
                     .font(.system(size: 17, weight: .semibold))
-                    .foregroundStyle(statusColor(for: unit))
+                    .foregroundStyle(statusColor(for: contact))
             }
 
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 7) {
-                    Text(unitLabel(for: unit))
+                    Text(contactName(for: contact))
                         .font(.headline)
                         .foregroundStyle(.primary)
                         .lineLimit(1)
                         .minimumScaleFactor(0.82)
 
-                    if unit.contactCount > 1 {
-                        Label("\(unit.contactCount)", systemImage: "person.2.fill")
-                            .font(.caption2.weight(.semibold))
-                            .foregroundStyle(.blue)
-                            .padding(.horizontal, 7)
-                            .padding(.vertical, 3)
-                            .background(Color.blue.opacity(0.1), in: Capsule())
-                    }
-
-                    if unit.hasCustomer {
+                    if contact.isCustomer {
                         Image(systemName: "star.fill")
                             .font(.caption.weight(.bold))
                             .foregroundStyle(.yellow)
@@ -164,7 +138,7 @@ struct UnitSelectorPopupView: View {
                     }
                 }
 
-                Text(unitSubtitle(for: unit))
+                Text(contactSubtitle(for: contact))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -207,10 +181,10 @@ struct UnitSelectorPopupView: View {
         .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 
-    private func select(_ unit: UnitContactGroup) {
+    private func select(_ contact: UnitContact) {
         MapScreenHapticsController.shared.propertyAdded()
         MapScreenSoundController.shared.playPropertyAdded()
-        onSelect(unit)
+        onSelect(contact)
     }
 
     private func closePopup() {
@@ -219,13 +193,7 @@ struct UnitSelectorPopupView: View {
         onClose()
     }
 
-    private func unitLabel(for unit: UnitContactGroup) -> String {
-        if let unitNumber = unit.unit {
-            return "Unit \(unitNumber)"
-        }
-
-        guard let contact = unit.primaryContact else { return "Main" }
-
+    private func contactName(for contact: UnitContact) -> String {
         switch contact {
         case .prospect(let prospect):
             return prospect.fullName
@@ -234,42 +202,25 @@ struct UnitSelectorPopupView: View {
         }
     }
 
-    private func unitSubtitle(for unit: UnitContactGroup) -> String {
-        let contactSummary = unit.contactCount == 1 ? "1 contact" : "\(unit.contactCount) contacts"
-        let knockSummary = unit.knockCount == 1 ? "1 knock" : "\(unit.knockCount) knocks"
-
-        guard unit.contactCount == 1, let contact = unit.primaryContact else {
-            return "\(contactSummary) - \(knockSummary)"
-        }
-
-        let contactName: String
-        switch contact {
-        case .prospect(let prospect):
-            contactName = prospect.fullName
-        case .customer(let customer):
-            contactName = customer.fullName
-        }
-
-        return "\(contactName) - \(knockSummary)"
+    private func contactSubtitle(for contact: UnitContact) -> String {
+        let type = contact.isCustomer ? "Customer" : contact.isUnqualified ? "Unqualified prospect" : "Prospect"
+        let knocks = contact.knockCount == 1 ? "1 knock" : "\(contact.knockCount) knocks"
+        return "\(type) - \(knocks)"
     }
 
-    private func statusIcon(for unit: UnitContactGroup) -> String {
-        if unit.contactCount > 1 {
-            return "person.2.fill"
-        }
-
-        if unit.hasCustomer {
+    private func statusIcon(for contact: UnitContact) -> String {
+        if contact.isCustomer {
             return "star.fill"
         }
 
-        return unit.hasUnqualified ? "xmark.octagon.fill" : "person.crop.circle.badge.clock"
+        return contact.isUnqualified ? "xmark.octagon.fill" : "person.crop.circle.badge.clock"
     }
 
-    private func statusColor(for unit: UnitContactGroup) -> Color {
-        if unit.hasCustomer {
+    private func statusColor(for contact: UnitContact) -> Color {
+        if contact.isCustomer {
             return .green
         }
 
-        return unit.hasUnqualified ? .red : .blue
+        return contact.isUnqualified ? .red : .blue
     }
 }

--- a/d2d-territory-management-service/views/ProspectPopupView.swift
+++ b/d2d-territory-management-service/views/ProspectPopupView.swift
@@ -34,170 +34,201 @@ struct ProspectPopupView: View {
     var onViewDetails: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Spacer()
-                Button(action: {
-                    
-                    // ✅ Play haptic + sound when closing
-                    MapScreenHapticsController.shared.propertyAdded()
-                    MapScreenSoundController.shared.playPropertyAdded()
-                    
-                    // Then perform the original close action
-                    onClose()
-                }) {
-                    ZStack {
-                        // Red base
-                        Circle()
-                            .fill(Color.red)
-                            .frame(width: 18, height: 18)
-                            .shadow(color: .black.opacity(0.25), radius: 4, x: 0, y: 2)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                header
+                contactRow
+                propertySummary
 
-                        // Subtle top highlight for depth
-                        Circle()
-                            .stroke(Color.white.opacity(0.25), lineWidth: 1)
-                            .frame(width: 18, height: 18)
-
-                        // Black X
-                        Image(systemName: "xmark")
-                            .font(.system(size: 7, weight: .bold))
-                            .foregroundColor(.black)
+                if recordingFeaturesActive {
+                    if showOutcomeButtons {
+                        outcomesSection
                     }
-                }
-                .buttonStyle(.plain)
-            }
-
-            VStack(alignment: .leading, spacing: 2) {
-                ForEach(formattedAddressLines, id: \.self) { line in
-                    Text(line)
-                        .font(.headline)
-                        .multilineTextAlignment(.leading)
+                } else {
+                    outcomesSection
                 }
             }
-            .padding(.horizontal, 5)
-
-            Button(action: {
-                // ✅ Play haptic + sound when selecting the prospect name
-                MapScreenHapticsController.shared.propertyAdded()
-                MapScreenSoundController.shared.playPropertyAdded()
-                
-                // Then perform the original action
-                onViewDetails()
-            }) {
-                HStack(spacing: 4) {
-                    Text(findProspectName())
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                }
-                .foregroundColor(.blue)
-            }
-            .padding(.horizontal, 5)
-            .buttonStyle(.plain)
-
-            Divider().padding(.vertical, 4)
-
-            // When features are active: show Record/Skip first, then outcomes.
-            // When locked or off: always show outcomes (no recording UI).
-            if recordingFeaturesActive {
-
-                if showOutcomeButtons {
-                    outcomeHeader
-                    outcomeButtons
-                }
-            } else {
-                // Locked or turned off: act like recording is off and show outcomes only
-                outcomeHeader
-                outcomeButtons
-            }
+            .padding(.horizontal, 18)
+            .padding(.top, 10)
+            .padding(.bottom, 14)
         }
+        .scrollIndicators(.hidden)
+        .background(Color(.systemGroupedBackground))
         .onAppear {
             if recordingFeaturesActive {
-                startRecording()   // automatically start recording if mode is on
+                startRecording()
             } else {
                 showOutcomeButtons = true
             }
         }
-        .padding()
-        .frame(width: 260)
-        .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(.ultraThinMaterial)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .strokeBorder(Color.white.opacity(0.3), lineWidth: 1)
-                )
-                .shadow(color: Color.black.opacity(0.2), radius: 10, x: 0, y: 4)
-        )
-        .cornerRadius(16)
-        .shadow(radius: 6)
     }
 
     // MARK: - Subviews
 
-    private var outcomeHeader: some View {
-        Text("Select Knock Outcome")
-            .font(.caption)
-            .foregroundColor(.gray)
+    private var header: some View {
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(accentColor.opacity(0.14))
+                    .frame(width: 48, height: 48)
+
+                Image(systemName: statusIcon)
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(accentColor)
+            }
+
+            VStack(alignment: .leading, spacing: 7) {
+                HStack(spacing: 8) {
+                    Text(statusTitle)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(accentColor)
+
+                    if isRecording {
+                        Label("Recording", systemImage: "waveform")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.red)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Color.red.opacity(0.1), in: Capsule())
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(formattedAddressLines, id: \.self) { line in
+                        Text(line)
+                            .font(.headline.weight(.bold))
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.82)
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            Button(action: closePopup) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 34, height: 34)
+                    .background(Color(.secondarySystemGroupedBackground), in: Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
     }
 
+    private var contactRow: some View {
+        Button(action: openContactDetails) {
+            HStack(spacing: 12) {
+                Image(systemName: isCustomer ? "person.crop.circle.fill.badge.checkmark" : "person.crop.circle.badge.clock")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(accentColor)
+                    .frame(width: 34, height: 34)
+                    .background(accentColor.opacity(0.1), in: Circle())
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(findProspectName())
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+
+                    Text("View contact timeline and details")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(12)
+            .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var propertySummary: some View {
+        HStack(spacing: 10) {
+            metricTile(value: "\(place.count)", label: knockSubtitle, systemName: "hand.tap.fill", tint: place.markerColor)
+            metricTile(value: "\(place.contactCount)", label: place.contactCount == 1 ? "Contact" : "Contacts", systemName: "person.2.fill", tint: .blue)
+            metricTile(value: "\(place.unitCount)", label: place.unitCount == 1 ? "Unit" : "Units", systemName: "building.2.fill", tint: .indigo)
+        }
+    }
+
+    private var outcomesSection: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text("Log Knock Outcome")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+
+            outcomeButtons
+        }
+    }
+
+    @ViewBuilder
     private var outcomeButtons: some View {
         if !isCustomer {
             let columns = [
                 GridItem(.flexible()),
                 GridItem(.flexible())
             ]
-            
-            return AnyView(
-                LazyVGrid(columns: columns, spacing: 12) {
-                    
-                    if place.isUnqualified {
-                        iconButton(
-                            systemName: "house.slash.fill",
-                            label: "Not Home",
-                            color: .gray
-                        ) { stopAndHandleOutcome("Wasn't Home") }
 
-                        iconButton(
-                            systemName: "arrow.uturn.backward.circle.fill",
-                            label: "Requalified",
-                            color: .green
-                        ) { stopAndHandleOutcome("Requalified") }
-                    } else {
-                        iconButton(
-                            systemName: "xmark.octagon.fill",
-                            label: "Unqualified",
-                            color: .red
-                        ) { stopAndHandleOutcome("Unqualified") }
+            LazyVGrid(columns: columns, spacing: 8) {
+                if place.isUnqualified {
+                    iconButton(
+                        systemName: "house.slash.fill",
+                        label: "Not Home",
+                        color: .gray
+                    ) { stopAndHandleOutcome("Wasn't Home") }
 
-                        iconButton(
-                            systemName: "house.slash.fill",
-                            label: "Not Home",
-                            color: .gray
-                        ) { stopAndHandleOutcome("Wasn't Home") }
+                    iconButton(
+                        systemName: "arrow.uturn.backward.circle.fill",
+                        label: "Requalified",
+                        color: .green
+                    ) { stopAndHandleOutcome("Requalified") }
+                } else {
+                    iconButton(
+                        systemName: "xmark.octagon.fill",
+                        label: "Unqualified",
+                        color: .red
+                    ) { stopAndHandleOutcome("Unqualified") }
 
-                        iconButton(
-                            systemName: "calendar.badge.clock",
-                            label: "Follow Up",
-                            color: .orange
-                        ) { stopAndHandleOutcome("Follow Up Later") }
+                    iconButton(
+                        systemName: "house.slash.fill",
+                        label: "Not Home",
+                        color: .gray
+                    ) { stopAndHandleOutcome("Wasn't Home") }
 
-                        iconButton(
-                            systemName: "checkmark.seal.fill",
-                            label: "Sale",
-                            color: .green
-                        ) { stopAndHandleOutcome("Converted To Sale") }
-                    }
+                    iconButton(
+                        systemName: "calendar.badge.clock",
+                        label: "Follow Up",
+                        color: .orange
+                    ) { stopAndHandleOutcome("Follow Up Later") }
+
+                    iconButton(
+                        systemName: "checkmark.seal.fill",
+                        label: "Sale",
+                        color: .green
+                    ) { stopAndHandleOutcome("Converted To Sale") }
                 }
-                .padding(.top, 4)
-            )
-        }
-        
-        // Customer outcomes: all in one row
-        return AnyView(
-            HStack(spacing: 12) {
+            }
+            .fixedSize(horizontal: false, vertical: true)
+        } else {
+            let columns = [
+                GridItem(.flexible()),
+                GridItem(.flexible()),
+                GridItem(.flexible())
+            ]
+
+            LazyVGrid(columns: columns, spacing: 8) {
                 iconButton(
                     systemName: "person.crop.circle.badge.xmark",
-                    label: "Customer Lost",
+                    label: "Lost",
                     color: .red
                 ) { stopAndHandleOutcome("Customer Lost") }
 
@@ -213,8 +244,7 @@ struct ProspectPopupView: View {
                     color: .orange
                 ) { stopAndHandleOutcome("Follow Up Later") }
             }
-            .padding(.top, 4)
-        )
+        }
     }
 
     private func recordingActionButton(systemName: String, label: String, color: Color, action: @escaping () -> Void) -> some View {
@@ -240,22 +270,93 @@ struct ProspectPopupView: View {
 
     private func iconButton(systemName: String, label: String, color: Color, action: @escaping () -> Void) -> some View {
         Button(action: action) {
-            VStack(spacing: 4) {
+            VStack(spacing: 5) {
                 Image(systemName: systemName)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 28, height: 28)
-                    .foregroundColor(color)
+                    .font(.system(size: 19, weight: .semibold))
+                    .foregroundStyle(color)
+                    .frame(width: 30, height: 30)
+                    .background(color.opacity(0.11), in: Circle())
+
                 Text(label)
-                    .font(.caption2)
-                    .foregroundColor(.primary)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
             }
-            .frame(width: 64)
+            .frame(maxWidth: .infinity)
+            .frame(height: 66)
+            .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
         .buttonStyle(.plain)
     }
 
+    private func metricTile(value: String, label: String, systemName: String, tint: Color) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: systemName)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(tint)
+                .frame(width: 22, height: 22)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(value)
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Text(label)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
     // MARK: - Helpers
+
+    private var statusTitle: String {
+        if isCustomer {
+            return "Customer"
+        }
+
+        return place.isUnqualified ? "Unqualified Prospect" : "Prospect"
+    }
+
+    private var statusIcon: String {
+        if isCustomer {
+            return "checkmark.seal.fill"
+        }
+
+        return place.isUnqualified ? "xmark.octagon.fill" : "mappin.and.ellipse"
+    }
+
+    private var accentColor: Color {
+        if isCustomer {
+            return .green
+        }
+
+        return place.isUnqualified ? .red : .blue
+    }
+
+    private var knockSubtitle: String {
+        place.count == 1 ? "Knock" : "Knocks"
+    }
+
+    private func closePopup() {
+        MapScreenHapticsController.shared.propertyAdded()
+        MapScreenSoundController.shared.playPropertyAdded()
+        onClose()
+    }
+
+    private func openContactDetails() {
+        MapScreenHapticsController.shared.propertyAdded()
+        MapScreenSoundController.shared.playPropertyAdded()
+        onViewDetails()
+    }
 
     private var formattedAddressLines: [String] {
         let parts = place.address.components(separatedBy: ",")

--- a/d2d-territory-management-service/views/UnitSelectorPopupView.swift
+++ b/d2d-territory-management-service/views/UnitSelectorPopupView.swift
@@ -13,112 +13,242 @@ struct UnitSelectorPopupView: View {
     let onSelect: (UnitContact) -> Void
     let onClose: () -> Void
 
+    private var customerCount: Int {
+        units.filter(\.isCustomer).count
+    }
+
+    private var unqualifiedCount: Int {
+        units.filter(\.isUnqualified).count
+    }
+
+    private var prospectCount: Int {
+        units.count - customerCount
+    }
+
     var body: some View {
-        VStack(spacing: 12) {
-            HStack {
-                Spacer()
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            summaryRow
+            unitList
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 12)
+        .padding(.bottom, 16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Color(.systemGroupedBackground))
+    }
 
-                Button(action: {
-                    // ✅ Play haptic + sound when closing
-                    MapScreenHapticsController.shared.propertyAdded()
-                    MapScreenSoundController.shared.playPropertyAdded()
+    private var header: some View {
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color.indigo.opacity(0.14))
+                    .frame(width: 48, height: 48)
 
-                    // Close action
-                    onClose()
-                }) {
-                    ZStack {
-                        // Red base
-                        Circle()
-                            .fill(Color.red)
-                            .frame(width: 18, height: 18)
-                            .shadow(color: .black.opacity(0.25), radius: 2, x: 0, y: 1)
-
-                        // Subtle top highlight for depth
-                        Circle()
-                            .stroke(Color.white.opacity(0.25), lineWidth: 1)
-                            .frame(width: 18, height: 18)
-
-                        // Black X in the center
-                        Image(systemName: "xmark")
-                            .font(.system(size: 7, weight: .bold))
-                            .foregroundColor(.black)
-                    }
-                }
-                .buttonStyle(.plain)
-                .contentShape(Circle()) // ensures tap area matches circle
-                
+                Image(systemName: "building.2.fill")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(.indigo)
             }
 
-            Text(baseAddress)
-                .font(.headline)
-                .multilineTextAlignment(.center)
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Multi-Unit Property")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.indigo)
 
-            Divider()
+                Text(baseAddress)
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.82)
+            }
+
+            Spacer(minLength: 0)
+
+            Button(action: closePopup) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 34, height: 34)
+                    .background(Color(.secondarySystemGroupedBackground), in: Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close")
+        }
+    }
+
+    private var summaryRow: some View {
+        HStack(spacing: 8) {
+            summaryTile(value: "\(units.count)", label: units.count == 1 ? "Unit" : "Units", systemName: "door.left.hand.open", tint: .indigo)
+            summaryTile(value: "\(prospectCount)", label: prospectCount == 1 ? "Prospect" : "Prospects", systemName: "person.crop.circle.badge.clock", tint: .blue)
+            summaryTile(value: "\(customerCount)", label: customerCount == 1 ? "Customer" : "Customers", systemName: "checkmark.seal.fill", tint: .green)
+        }
+    }
+
+    private var unitList: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Select Unit")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+
+                Spacer()
+
+                if unqualifiedCount > 0 {
+                    Label("\(unqualifiedCount)", systemImage: "xmark.octagon.fill")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.red)
+                }
+            }
 
             ScrollView {
-                VStack(spacing: 8) {
+                LazyVStack(spacing: 8) {
                     ForEach(units) { unit in
                         Button {
-                            onSelect(unit)
+                            select(unit)
                         } label: {
-                            HStack {
-                                Text(unitLabel(for: unit))
-                                    .font(.headline)
-
-                                if unit.isUnqualified {
-                                    ZStack {
-                                        Circle()
-                                            .fill(Color.red)
-                                            .frame(width: 18, height: 18)
-
-                                        Image(systemName: "xmark")
-                                            .font(.system(size: 10, weight: .bold))
-                                            .foregroundStyle(.white)
-                                    }
-                                }
-                                else if unit.isCustomer {
-                                    Image(systemName: "star.fill")
-                                        .foregroundStyle(.yellow)
-                                }
-
-                                Spacer()
-
-                                Image(systemName: "chevron.right")
-                                    .foregroundStyle(.secondary)
-                            }
-                            .padding()
-                            .background(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .fill(.ultraThinMaterial)
-                            )
+                            unitRow(for: unit)
                         }
                         .buttonStyle(.plain)
                     }
                 }
+                .padding(.bottom, 2)
             }
+            .scrollIndicators(.hidden)
         }
-        .padding()
-        .frame(width: 280, height: 320)
-        .background(.ultraThinMaterial)
-        .cornerRadius(18)
-        .shadow(radius: 8)
     }
 
-    private func unitLabel(for address: String) -> String {
-        parseAddress(address).unit.map { "Unit \($0)" } ?? "Main"
+    private func unitRow(for unit: UnitContact) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(statusColor(for: unit).opacity(0.12))
+                    .frame(width: 38, height: 38)
+
+                Image(systemName: statusIcon(for: unit))
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(statusColor(for: unit))
+            }
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 7) {
+                    Text(unitLabel(for: unit))
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.82)
+
+                    Text(statusLabel(for: unit))
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(statusColor(for: unit))
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 3)
+                        .background(statusColor(for: unit).opacity(0.1), in: Capsule())
+                }
+
+                Text(unitSubtitle(for: unit))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+
+            Spacer(minLength: 0)
+
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
-    
+
+    private func summaryTile(value: String, label: String, systemName: String, tint: Color) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: systemName)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(tint)
+                .frame(width: 22, height: 22)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(value)
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(.primary)
+
+                Text(label)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+            }
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private func select(_ unit: UnitContact) {
+        MapScreenHapticsController.shared.propertyAdded()
+        MapScreenSoundController.shared.playPropertyAdded()
+        onSelect(unit)
+    }
+
+    private func closePopup() {
+        MapScreenHapticsController.shared.propertyAdded()
+        MapScreenSoundController.shared.playPropertyAdded()
+        onClose()
+    }
+
     private func unitLabel(for unit: UnitContact) -> String {
         if let unitNumber = parseAddress(unit.address).unit {
             return "Unit \(unitNumber)"
-        } else {
-            // Use the Prospect/Customer fullName
-            switch unit {
-            case .prospect(let p):
-                return p.fullName
-            case .customer(let c):
-                return c.fullName
-            }
         }
+
+        switch unit {
+        case .prospect(let prospect):
+            return prospect.fullName
+        case .customer(let customer):
+            return customer.fullName
+        }
+    }
+
+    private func unitSubtitle(for unit: UnitContact) -> String {
+        let contactName: String
+
+        switch unit {
+        case .prospect(let prospect):
+            contactName = prospect.fullName
+        case .customer(let customer):
+            contactName = customer.fullName
+        }
+
+        let knocks = unit.knockCount == 1 ? "1 knock" : "\(unit.knockCount) knocks"
+        return "\(contactName) - \(knocks)"
+    }
+
+    private func statusIcon(for unit: UnitContact) -> String {
+        if unit.isCustomer {
+            return "checkmark.seal.fill"
+        }
+
+        return unit.isUnqualified ? "xmark.octagon.fill" : "person.crop.circle.badge.clock"
+    }
+
+    private func statusLabel(for unit: UnitContact) -> String {
+        if unit.isCustomer {
+            return "Customer"
+        }
+
+        return unit.isUnqualified ? "Unqualified" : "Prospect"
+    }
+
+    private func statusColor(for unit: UnitContact) -> Color {
+        if unit.isCustomer {
+            return .green
+        }
+
+        return unit.isUnqualified ? .red : .blue
     }
 }


### PR DESCRIPTION
This PR improves the map popup experience across prospect, customer, multi-unit, and multi-contact workflows. Prospect and customer property popups now use more modern CRM-style bottom sheet layouts with clearer headers, contact detail rows, property context, and better-sized knock outcome actions. Customers now have their own dedicated popup with a shorter detent so the three customer actions do not leave awkward unused space. Multi-unit properties now open a redesigned full-width selector that groups contacts by unit instead of showing duplicate unit rows, displays contact-count badges for units with multiple contacts, and shows a customer/star indicator when any contact in that unit is a customer. A new multi-contact popup was added between the multi-unit selector and the final prospect/customer popup, so the flow is now multi-unit popup to multi-contact popup to prospect/customer popup when a unit contains multiple people. Single-property addresses with multiple contacts now get their own distinct map icon using a multi-person symbol, a count badge, and a customer star when applicable. Popup dismissal behavior was also tightened so closing a popup with the X button, swiping it down, or tapping the visible map area clears the selected marker state and allows the same address to be reopened immediately.