### PR TITLE
Bulk Property Marker Placement Improvements - July '26 Release

### DIFF
--- a/d2d-territory-management-service/MapSearchView.swift
+++ b/d2d-territory-management-service/MapSearchView.swift
@@ -444,9 +444,9 @@ struct MapSearchView: View {
 
                 for prop in bulk.properties {
 
-                    let snapped = await controller.snapToNearestRoad(coordinate: prop.coordinate)
-
-                    let address = await controller.reverseGeocode(coordinate: snapped) ?? "Unknown Address"
+                    guard let address = await controller.reverseGeocode(coordinate: prop.coordinate) else {
+                        continue
+                    }
 
                     let normalized = address.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -460,7 +460,9 @@ struct MapSearchView: View {
                     // Skip if duplicate inside this bulk
                     guard !existsGlobally, !seenAddresses.contains(normalized) else { continue }
 
-                    resolved.append(PendingAddProperty(address: address, coordinate: snapped))
+                    let propertyCoordinate = await controller.geocodeAddress(address) ?? prop.coordinate
+
+                    resolved.append(PendingAddProperty(address: address, coordinate: propertyCoordinate))
                     seenAddresses.insert(normalized)
                 }
 

--- a/d2d-territory-management-service/views/MapDisplayCoordinator.swift
+++ b/d2d-territory-management-service/views/MapDisplayCoordinator.swift
@@ -140,10 +140,9 @@ final class MapDisplayCoordinator: NSObject, MKMapViewDelegate {
                     )
                 }
 
-        // 2️⃣ If NONE found → generate new properties
-        if properties.isEmpty {
-            properties = generateGrid(center: center, count: 6)
-        }
+        // 2️⃣ Always probe the area too. Existing markers are filtered later,
+        // so a partially filled circle can still surface nearby new addresses.
+        properties += generateGrid(center: center, count: 6)
 
         NotificationCenter.default.post(
             name: .didRequestBulkAdd,


### PR DESCRIPTION
The D2D CRM app now improves the bulk property add workflow on the map so that newly added prospects are placed on the actual property location instead of being saved to a snapped street coordinate. Bulk add now resolves each detected address back to the same property coordinate used by single property adds, address search, and prospect detail address updates, making marker placement more consistent across the app. This update also improves partially filled bulk-add circles by continuing to surface nearby new addresses even when existing prospects or customers are already inside the selected radius. Existing duplicate filtering remains in place, so reps only see properties that still need to be added. These improvements make bulk property creation clearer and more reliable in the field, helping reps quickly understand which marker belongs to which property.