### PR TITLE
Implementing initial removable scorecard feature for map screen - July '26 Feature Release

### DIFF
--- a/d2d-customer-details-management-service/CustomerDetailsView.swift
+++ b/d2d-customer-details-management-service/CustomerDetailsView.swift
@@ -77,37 +77,10 @@ struct CustomerDetailsView: View {
                 .listRowInsets(EdgeInsets(top: 2, leading: 0, bottom: 2, trailing: 0))
                 
                 Section {
-                    HStack(spacing: 12) {
-                        CustomerDetailsScorecard(
-                            title: "Meetings",
-                            value: "\(customer.appointments.filter { $0.date >= Date() }.count)",
-                            icon: "calendar.badge.clock",
-                            color: .blue
-                        ) {
-                            
-                            // ✅ Play haptic + sound when opening knocking history
-                            ContactScreenHapticsController.shared.lightTap()
-                            ContactScreenSoundController.shared.playSound1()
-                            
-                            showAppointmentsSheet = true
-                            
-                        }
-
-                        CustomerDetailsScorecard(
-                            title: "Knocks",
-                            value: "\(customer.knockHistory.count)",
-                            icon: "hand.tap.fill",
-                            color: .orange
-                        ) {
-                            
-                            // ✅ Play haptic + sound when opening knocking history
-                            ContactScreenHapticsController.shared.lightTap()
-                            ContactScreenSoundController.shared.playSound1()
-                            
-                            showKnocksSheet = true
-                        }
-                    }
-                    .padding(.horizontal, 10)
+                    DetailsScorecardCustomizationView(
+                        storagePrefix: "customerDetails",
+                        items: customerScorecardItems
+                    )
                 }
                 .listRowInsets(EdgeInsets(top: 2, leading: 0, bottom: 2, trailing: 0))
                 .listRowBackground(Color.clear)
@@ -308,6 +281,35 @@ struct CustomerDetailsView: View {
         }
     }
     
+    private var customerScorecardItems: [DetailsScorecardItem] {
+        [
+            DetailsScorecardItem(
+                kind: .meetings,
+                title: "Meetings",
+                value: "\(customer.appointments.filter { $0.date >= Date() }.count)",
+                icon: "calendar.badge.clock",
+                color: .blue,
+                action: {
+                    ContactScreenHapticsController.shared.lightTap()
+                    ContactScreenSoundController.shared.playSound1()
+                    showAppointmentsSheet = true
+                }
+            ),
+            DetailsScorecardItem(
+                kind: .knocks,
+                title: "Knocks",
+                value: "\(customer.knockHistory.count)",
+                icon: "hand.tap.fill",
+                color: .orange,
+                action: {
+                    ContactScreenHapticsController.shared.lightTap()
+                    ContactScreenSoundController.shared.playSound1()
+                    showKnocksSheet = true
+                }
+            )
+        ]
+    }
+
     private func exportToContacts() {
         let store = CNContactStore()
         

--- a/d2d-map-screen-analytics-service/ScorecardBar.swift
+++ b/d2d-map-screen-analytics-service/ScorecardBar.swift
@@ -7,17 +7,316 @@
 import SwiftUI
 
 struct ScorecardBar: View {
+    @AppStorage("mapScorecardKnocksVisible") private var isKnocksVisible: Bool = true
+    @AppStorage("mapScorecardSalesVisible") private var isSalesVisible: Bool = true
+
+    @State private var editingScorecard: MapScorecardKind?
+    @State private var isShowingRestoreTargets = false
+
+    private enum MapScorecardKind: String, Identifiable, CaseIterable {
+        case knocks
+        case sales
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .knocks:
+                "Today's Knocks"
+            case .sales:
+                "Today's Sales"
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .knocks:
+                "door.left.hand.open"
+            case .sales:
+                "checkmark.seal.fill"
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .knocks:
+                .blue
+            case .sales:
+                .green
+            }
+        }
+    }
 
     var body: some View {
-        HStack(spacing: 12) {
-            
-            DailyKnocksTrackerView()
-            
-            DailySalesTrackerView()
-
+        VStack(spacing: 10) {
+            if visibleKinds.isEmpty {
+                restoreBanner
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            } else {
+                scorecardStack
+                    .transition(.scale(scale: 0.98).combined(with: .opacity))
+            }
         }
+        .padding(.horizontal, 16)
         .padding(.top, 10)
-        .frame(maxWidth: .infinity, alignment: .center)
+        .frame(maxWidth: .infinity, alignment: .top)
         .zIndex(1)
+        .animation(.spring(response: 0.32, dampingFraction: 0.82), value: visibleKinds.map(\.id))
+        .animation(.spring(response: 0.24, dampingFraction: 0.8), value: editingScorecard?.id)
+        .animation(.spring(response: 0.24, dampingFraction: 0.8), value: isShowingRestoreTargets)
+    }
+
+    private var scorecardStack: some View {
+        HStack(alignment: .top, spacing: 12) {
+            ForEach(visibleKinds) { kind in
+                scorecardSlot(for: kind)
+                    .frame(maxWidth: visibleKinds.count == 1 ? .infinity : 190)
+            }
+        }
+        .frame(maxWidth: visibleKinds.count == 1 ? .infinity : 420, alignment: .center)
+    }
+
+    private func scorecardSlot(for kind: MapScorecardKind) -> some View {
+        VStack(spacing: 8) {
+            scorecard(for: kind)
+                .overlay {
+                    if editingScorecard == kind {
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .stroke(
+                                Color.red,
+                                style: StrokeStyle(lineWidth: 2, dash: [7, 5])
+                            )
+                    }
+                }
+                .overlay(alignment: .topTrailing) {
+                    if editingScorecard == kind {
+                        Button {
+                            hide(kind)
+                        } label: {
+                            Image(systemName: "minus.circle.fill")
+                                .font(.system(size: 22, weight: .semibold))
+                                .symbolRenderingMode(.palette)
+                                .foregroundStyle(.white, .red)
+                                .frame(width: 30, height: 30)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(6)
+                        .accessibilityLabel("Remove \(kind.title) Scorecard")
+                    }
+                }
+                .contentShape(Rectangle())
+                .simultaneousGesture(
+                    LongPressGesture(minimumDuration: 0.5)
+                        .onEnded { _ in
+                            beginEditing(kind)
+                        }
+                )
+
+            if editingScorecard == kind {
+                removePrompt(for: kind)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+
+                if hiddenKinds.isEmpty == false {
+                    restoreTargetRow(for: hiddenKinds)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func scorecard(for kind: MapScorecardKind) -> some View {
+        switch kind {
+        case .knocks:
+            DailyKnocksTrackerView(isExpanded: visibleKinds.count == 1)
+        case .sales:
+            DailySalesTrackerView(isExpanded: visibleKinds.count == 1)
+        }
+    }
+
+    private func removePrompt(for kind: MapScorecardKind) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 8) {
+                Image(systemName: "minus.circle")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(.red)
+                    .frame(width: 30, height: 30)
+                    .background(Color.red.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                Text("Remove \(kind.title)")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
+            }
+
+            HStack(spacing: 8) {
+                Button {
+                    cancelEditing()
+                } label: {
+                    Text("Cancel")
+                        .font(.caption.weight(.semibold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 32)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                Button {
+                    hide(kind)
+                } label: {
+                    Text("Remove")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 32)
+                }
+                .buttonStyle(.plain)
+                .background(Color.red, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: visibleKinds.count == 1 ? .infinity : 190)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.white.opacity(0.32), lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.18), radius: 12, x: 0, y: 6)
+    }
+
+    private var restoreBanner: some View {
+        VStack(spacing: 10) {
+            Button {
+                requestRestoreTargets()
+            } label: {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 28, weight: .semibold))
+                    .foregroundStyle(.blue)
+                    .frame(width: 54, height: 54)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .stroke(Color.blue.opacity(0.24), lineWidth: 1)
+                    )
+                    .shadow(color: Color.black.opacity(0.16), radius: 12, x: 0, y: 7)
+            }
+            .buttonStyle(.plain)
+            .contentShape(Rectangle())
+            .simultaneousGesture(
+                LongPressGesture(minimumDuration: 0.5)
+                    .onEnded { _ in
+                        requestRestoreTargets()
+                    }
+            )
+            .accessibilityLabel("Add Scorecards")
+
+            if isShowingRestoreTargets {
+                restoreTargetRow(for: MapScorecardKind.allCases)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func restoreTargetRow(for kinds: [MapScorecardKind]) -> some View {
+        HStack(spacing: 10) {
+            ForEach(kinds) { kind in
+                restoreTarget(for: kind)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func restoreTarget(for kind: MapScorecardKind) -> some View {
+        Button {
+            restore(kind)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: kind.icon)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(kind.color)
+
+                Text(kind.title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(kind.color)
+            }
+            .padding(.horizontal, 10)
+            .frame(maxWidth: .infinity)
+            .frame(height: 46)
+            .background(kind.color.opacity(0.06), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(
+                        kind.color,
+                        style: StrokeStyle(lineWidth: 1.6, dash: [6, 5])
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Add \(kind.title) Scorecard")
+    }
+
+    private var visibleKinds: [MapScorecardKind] {
+        MapScorecardKind.allCases.filter { isVisible($0) }
+    }
+
+    private var hiddenKinds: [MapScorecardKind] {
+        MapScorecardKind.allCases.filter { !isVisible($0) }
+    }
+
+    private func isVisible(_ kind: MapScorecardKind) -> Bool {
+        switch kind {
+        case .knocks:
+            isKnocksVisible
+        case .sales:
+            isSalesVisible
+        }
+    }
+
+    private func beginEditing(_ kind: MapScorecardKind) {
+        MapScreenHapticsController.shared.lightTap()
+        editingScorecard = kind
+        isShowingRestoreTargets = false
+    }
+
+    private func cancelEditing() {
+        MapScreenHapticsController.shared.lightTap()
+        editingScorecard = nil
+    }
+
+    private func hide(_ kind: MapScorecardKind) {
+        MapScreenHapticsController.shared.lightTap()
+        switch kind {
+        case .knocks:
+            isKnocksVisible = false
+        case .sales:
+            isSalesVisible = false
+        }
+        editingScorecard = nil
+    }
+
+    private func requestRestoreTargets() {
+        MapScreenHapticsController.shared.lightTap()
+        isShowingRestoreTargets = true
+    }
+
+    private func restore(_ kind: MapScorecardKind) {
+        MapScreenHapticsController.shared.lightTap()
+        MapScreenSoundController.shared.playPropertyOpen()
+        switch kind {
+        case .knocks:
+            isKnocksVisible = true
+        case .sales:
+            isSalesVisible = true
+        }
+        isShowingRestoreTargets = false
     }
 }

--- a/d2d-map-screen-analytics-service/ScorecardBar.swift
+++ b/d2d-map-screen-analytics-service/ScorecardBar.swift
@@ -7,10 +7,13 @@
 import SwiftUI
 
 struct ScorecardBar: View {
+    @Binding var isCustomizingScorecards: Bool
+
     @AppStorage("mapScorecardKnocksVisible") private var isKnocksVisible: Bool = true
     @AppStorage("mapScorecardSalesVisible") private var isSalesVisible: Bool = true
 
     @State private var editingScorecard: MapScorecardKind?
+    @State private var confirmingRemoval: MapScorecardKind?
     @State private var isShowingRestoreTargets = false
 
     private enum MapScorecardKind: String, Identifiable, CaseIterable {
@@ -90,36 +93,47 @@ struct ScorecardBar: View {
                 }
                 .overlay(alignment: .topTrailing) {
                     if editingScorecard == kind {
-                        Button {
-                            hide(kind)
-                        } label: {
-                            Image(systemName: "minus.circle.fill")
-                                .font(.system(size: 22, weight: .semibold))
-                                .symbolRenderingMode(.palette)
-                                .foregroundStyle(.white, .red)
-                                .frame(width: 30, height: 30)
+                        HStack(spacing: 6) {
+                            if visibleKinds.count == 1, let hiddenKind = hiddenKinds.first {
+                                Button {
+                                    restore(hiddenKind)
+                                } label: {
+                                    Image(systemName: "plus.circle.fill")
+                                        .font(.system(size: 22, weight: .semibold))
+                                        .symbolRenderingMode(.palette)
+                                        .foregroundStyle(.white, hiddenKind.color)
+                                        .frame(width: 30, height: 30)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Add \(hiddenKind.title) Scorecard")
+                            }
+
+                            Button {
+                                requestRemovalConfirmation(for: kind)
+                            } label: {
+                                Image(systemName: "minus.circle.fill")
+                                    .font(.system(size: 22, weight: .semibold))
+                                    .symbolRenderingMode(.palette)
+                                    .foregroundStyle(.white, .red)
+                                    .frame(width: 30, height: 30)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Remove \(kind.title) Scorecard")
                         }
-                        .buttonStyle(.plain)
                         .padding(6)
-                        .accessibilityLabel("Remove \(kind.title) Scorecard")
                     }
                 }
                 .contentShape(Rectangle())
-                .simultaneousGesture(
+                .highPriorityGesture(
                     LongPressGesture(minimumDuration: 0.5)
                         .onEnded { _ in
                             beginEditing(kind)
                         }
                 )
 
-            if editingScorecard == kind {
+            if confirmingRemoval == kind {
                 removePrompt(for: kind)
                     .transition(.move(edge: .top).combined(with: .opacity))
-
-                if hiddenKinds.isEmpty == false {
-                    restoreTargetRow(for: hiddenKinds)
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                }
             }
         }
     }
@@ -128,9 +142,15 @@ struct ScorecardBar: View {
     private func scorecard(for kind: MapScorecardKind) -> some View {
         switch kind {
         case .knocks:
-            DailyKnocksTrackerView(isExpanded: visibleKinds.count == 1)
+            DailyKnocksTrackerView(
+                isExpanded: visibleKinds.count == 1,
+                isCustomizationActive: isCustomizingScorecards
+            )
         case .sales:
-            DailySalesTrackerView(isExpanded: visibleKinds.count == 1)
+            DailySalesTrackerView(
+                isExpanded: visibleKinds.count == 1,
+                isCustomizationActive: isCustomizingScorecards
+            )
         }
     }
 
@@ -196,7 +216,7 @@ struct ScorecardBar: View {
                     .frame(height: 96)
                     .frame(maxWidth: .infinity)
                     .contentShape(Rectangle())
-                    .simultaneousGesture(
+                    .highPriorityGesture(
                         LongPressGesture(minimumDuration: 0.5)
                             .onEnded { _ in
                                 requestRestoreTargets()
@@ -246,14 +266,17 @@ struct ScorecardBar: View {
         .frame(maxWidth: .infinity)
     }
 
+
     private func restoreTarget(for kind: MapScorecardKind) -> some View {
         Button {
             restore(kind)
         } label: {
             HStack(spacing: 8) {
                 Image(systemName: kind.icon)
-                    .font(.system(size: 15, weight: .semibold))
+                    .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(kind.color)
+                    .frame(width: 24, height: 24)
+                    .background(kind.color.opacity(0.12), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
 
                 Text(kind.title)
                     .font(.caption.weight(.semibold))
@@ -261,14 +284,18 @@ struct ScorecardBar: View {
                     .lineLimit(1)
                     .minimumScaleFactor(0.72)
 
-                Image(systemName: "plus.circle.fill")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(kind.color)
+                Spacer(minLength: 0)
+
+                Image(systemName: "plus")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 22, height: 22)
+                    .background(kind.color, in: Circle())
             }
             .padding(.horizontal, 10)
             .frame(maxWidth: .infinity)
             .frame(height: 46)
-            .background(kind.color.opacity(0.06), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .background(kind.color.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .stroke(
@@ -301,12 +328,22 @@ struct ScorecardBar: View {
     private func beginEditing(_ kind: MapScorecardKind) {
         MapScreenHapticsController.shared.lightTap()
         editingScorecard = kind
+        confirmingRemoval = nil
         isShowingRestoreTargets = false
+        updateCustomizationState()
+    }
+
+    private func requestRemovalConfirmation(for kind: MapScorecardKind) {
+        MapScreenHapticsController.shared.lightTap()
+        confirmingRemoval = kind
+        updateCustomizationState()
     }
 
     private func cancelEditing() {
         MapScreenHapticsController.shared.lightTap()
         editingScorecard = nil
+        confirmingRemoval = nil
+        updateCustomizationState()
     }
 
     private func hide(_ kind: MapScorecardKind) {
@@ -318,11 +355,14 @@ struct ScorecardBar: View {
             isSalesVisible = false
         }
         editingScorecard = nil
+        confirmingRemoval = nil
+        updateCustomizationState()
     }
 
     private func requestRestoreTargets() {
         MapScreenHapticsController.shared.lightTap()
         isShowingRestoreTargets = true
+        updateCustomizationState()
     }
 
     private func restore(_ kind: MapScorecardKind) {
@@ -334,6 +374,13 @@ struct ScorecardBar: View {
         case .sales:
             isSalesVisible = true
         }
+        editingScorecard = nil
+        confirmingRemoval = nil
         isShowingRestoreTargets = false
+        updateCustomizationState()
+    }
+
+    private func updateCustomizationState() {
+        isCustomizingScorecards = editingScorecard != nil || confirmingRemoval != nil || isShowingRestoreTargets
     }
 }

--- a/d2d-map-screen-analytics-service/ScorecardBar.swift
+++ b/d2d-map-screen-analytics-service/ScorecardBar.swift
@@ -50,8 +50,8 @@ struct ScorecardBar: View {
     var body: some View {
         VStack(spacing: 10) {
             if visibleKinds.isEmpty {
-                restoreBanner
-                    .transition(.move(edge: .top).combined(with: .opacity))
+                emptyScorecardRestoreZone
+                    .transition(.opacity)
             } else {
                 scorecardStack
                     .transition(.scale(scale: 0.98).combined(with: .opacity))
@@ -186,38 +186,55 @@ struct ScorecardBar: View {
         .shadow(color: Color.black.opacity(0.18), radius: 12, x: 0, y: 6)
     }
 
-    private var restoreBanner: some View {
-        VStack(spacing: 10) {
-            Button {
-                requestRestoreTargets()
-            } label: {
-                Image(systemName: "plus.circle.fill")
-                    .font(.system(size: 28, weight: .semibold))
-                    .foregroundStyle(.blue)
-                    .frame(width: 54, height: 54)
-                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 16, style: .continuous)
-                            .stroke(Color.blue.opacity(0.24), lineWidth: 1)
-                    )
-                    .shadow(color: Color.black.opacity(0.16), radius: 12, x: 0, y: 7)
-            }
-            .buttonStyle(.plain)
-            .contentShape(Rectangle())
-            .simultaneousGesture(
-                LongPressGesture(minimumDuration: 0.5)
-                    .onEnded { _ in
-                        requestRestoreTargets()
-                    }
-            )
-            .accessibilityLabel("Add Scorecards")
-
+    private var emptyScorecardRestoreZone: some View {
+        Group {
             if isShowingRestoreTargets {
-                restoreTargetRow(for: MapScorecardKind.allCases)
-                    .transition(.move(edge: .top).combined(with: .opacity))
+                restoreChooserCard
+                    .transition(.scale(scale: 0.98).combined(with: .opacity))
+            } else {
+                Color.clear
+                    .frame(height: 96)
+                    .frame(maxWidth: .infinity)
+                    .contentShape(Rectangle())
+                    .simultaneousGesture(
+                        LongPressGesture(minimumDuration: 0.5)
+                            .onEnded { _ in
+                                requestRestoreTargets()
+                            }
+                    )
+                    .accessibilityLabel("Show Scorecard Restore Options")
             }
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private var restoreChooserCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(.blue)
+                    .frame(width: 40, height: 40)
+                    .background(Color.blue.opacity(0.12), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+                Text("Choose first scorecard")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+            }
+
+            restoreTargetRow(for: MapScorecardKind.allCases)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, minHeight: 118, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.blue.opacity(0.24), lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.16), radius: 14, x: 0, y: 8)
     }
 
     private func restoreTargetRow(for kinds: [MapScorecardKind]) -> some View {

--- a/d2d-map-screen-analytics-service/views/DailyKnocksTrackerView.swift
+++ b/d2d-map-screen-analytics-service/views/DailyKnocksTrackerView.swift
@@ -15,6 +15,7 @@ struct DailyKnocksTrackerView: View {
     @State private var showSheet = false
 
     var isExpanded: Bool = false
+    var isCustomizationActive: Bool = false
 
     private var todayKnockCount: Int {
         let calendar = Calendar.current
@@ -27,6 +28,7 @@ struct DailyKnocksTrackerView: View {
 
     var body: some View {
         Button {
+            guard !isCustomizationActive else { return }
             
             // ✅ Haptics
             MapScreenHapticsController.shared.lightTap()

--- a/d2d-map-screen-analytics-service/views/DailyKnocksTrackerView.swift
+++ b/d2d-map-screen-analytics-service/views/DailyKnocksTrackerView.swift
@@ -14,6 +14,8 @@ struct DailyKnocksTrackerView: View {
     
     @State private var showSheet = false
 
+    var isExpanded: Bool = false
+
     private var todayKnockCount: Int {
         let calendar = Calendar.current
         let today = Date()
@@ -34,27 +36,30 @@ struct DailyKnocksTrackerView: View {
             
             showSheet = true
         } label: {
-            HStack(spacing: 12) {
+            HStack(spacing: isExpanded ? 16 : 12) {
                 Image(systemName: "door.left.hand.open")
-                    .font(.system(size: 19, weight: .semibold))
+                    .font(.system(size: isExpanded ? 24 : 19, weight: .semibold))
                     .foregroundStyle(.blue)
-                    .frame(width: 36, height: 36)
+                    .frame(width: isExpanded ? 50 : 36, height: isExpanded ? 50 : 36)
                     .background(Circle().fill(Color.blue.opacity(0.14)))
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: isExpanded ? 4 : 2) {
                     Text("Today's Knocks")
-                        .font(.caption)
+                        .font(isExpanded ? .subheadline : .caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
 
                     Text("\(todayKnockCount)")
-                        .font(.title2.weight(.bold))
+                        .font(isExpanded ? .largeTitle.weight(.bold) : .title2.weight(.bold))
                         .foregroundStyle(.primary)
                         .contentTransition(.numericText())
                 }
+
+                Spacer(minLength: 0)
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
+            .padding(.horizontal, isExpanded ? 18 : 16)
+            .padding(.vertical, isExpanded ? 14 : 10)
+            .frame(maxWidth: isExpanded ? .infinity : nil, minHeight: isExpanded ? 88 : nil, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
                     .fill(.regularMaterial)

--- a/d2d-map-screen-analytics-service/views/DailySalesTrackerView.swift
+++ b/d2d-map-screen-analytics-service/views/DailySalesTrackerView.swift
@@ -13,6 +13,8 @@ struct DailySalesTrackerView: View {
     @Query private var allKnocks: [Knock]
     @State private var showSheet = false
 
+    var isExpanded: Bool = false
+
     private var todayKnocks: [Knock] {
         let calendar = Calendar.current
         let today = Date()
@@ -38,27 +40,30 @@ struct DailySalesTrackerView: View {
             showSheet = true
             
         } label: {
-            HStack(spacing: 12) {
+            HStack(spacing: isExpanded ? 16 : 12) {
                 Image(systemName: "checkmark.seal.fill")
-                    .font(.system(size: 19, weight: .semibold))
+                    .font(.system(size: isExpanded ? 24 : 19, weight: .semibold))
                     .foregroundStyle(.green)
-                    .frame(width: 36, height: 36)
+                    .frame(width: isExpanded ? 50 : 36, height: isExpanded ? 50 : 36)
                     .background(Circle().fill(Color.green.opacity(0.14)))
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: isExpanded ? 4 : 2) {
                     Text("Today's Sales")
-                        .font(.caption)
+                        .font(isExpanded ? .subheadline : .caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
 
                     Text("\(todaySalesCount)")
-                        .font(.title2.weight(.bold))
+                        .font(isExpanded ? .largeTitle.weight(.bold) : .title2.weight(.bold))
                         .foregroundStyle(.primary)
                         .contentTransition(.numericText())
                 }
+
+                Spacer(minLength: 0)
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
+            .padding(.horizontal, isExpanded ? 18 : 16)
+            .padding(.vertical, isExpanded ? 14 : 10)
+            .frame(maxWidth: isExpanded ? .infinity : nil, minHeight: isExpanded ? 88 : nil, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
                     .fill(.regularMaterial)

--- a/d2d-map-screen-analytics-service/views/DailySalesTrackerView.swift
+++ b/d2d-map-screen-analytics-service/views/DailySalesTrackerView.swift
@@ -14,6 +14,7 @@ struct DailySalesTrackerView: View {
     @State private var showSheet = false
 
     var isExpanded: Bool = false
+    var isCustomizationActive: Bool = false
 
     private var todayKnocks: [Knock] {
         let calendar = Calendar.current
@@ -30,6 +31,7 @@ struct DailySalesTrackerView: View {
 
     var body: some View {
         Button {
+            guard !isCustomizationActive else { return }
             
             // ✅ Haptics
             MapScreenHapticsController.shared.lightTap()

--- a/d2d-prospect-details-management-service/ProspectDetailsView.swift
+++ b/d2d-prospect-details-management-service/ProspectDetailsView.swift
@@ -69,37 +69,10 @@ struct ProspectDetailsView: View {
                 .listRowInsets(EdgeInsets(top: 2, leading: 0, bottom: 2, trailing: 0))
                 
                 Section {
-                    HStack(spacing: 12) {
-                        ProspectScorecard(
-                            title: "Meetings",
-                            value: "\(prospect.appointments.filter { $0.date >= Date() }.count)",
-                            icon: "calendar.badge.clock",
-                            color: .blue
-                        ) {
-                            
-                            // ✅ Play haptic + sound when opening knocking history
-                            ContactScreenHapticsController.shared.lightTap()
-                            ContactScreenSoundController.shared.playSound1()
-                            
-                            showAppointmentsSheet = true
-                            
-                        }
-
-                        ProspectScorecard(
-                            title: "Knocks",
-                            value: "\(prospect.knockHistory.count)",
-                            icon: "hand.tap.fill",
-                            color: .orange
-                        ) {
-                            
-                            // ✅ Play haptic + sound when opening knocking history
-                            ContactScreenHapticsController.shared.lightTap()
-                            ContactScreenSoundController.shared.playSound1()
-                            
-                            showKnocksSheet = true
-                        }
-                    }
-                    .padding(.horizontal, 10) // ← give horizontal breathing room
+                    DetailsScorecardCustomizationView(
+                        storagePrefix: "prospectDetails",
+                        items: prospectScorecardItems
+                    )
                 }
                 .listRowInsets(EdgeInsets(top: 2, leading: 0, bottom: 2, trailing: 0))
                 .listRowBackground(Color.clear)
@@ -331,6 +304,35 @@ struct ProspectDetailsView: View {
         }
     }
     
+    private var prospectScorecardItems: [DetailsScorecardItem] {
+        [
+            DetailsScorecardItem(
+                kind: .meetings,
+                title: "Meetings",
+                value: "\(prospect.appointments.filter { $0.date >= Date() }.count)",
+                icon: "calendar.badge.clock",
+                color: .blue,
+                action: {
+                    ContactScreenHapticsController.shared.lightTap()
+                    ContactScreenSoundController.shared.playSound1()
+                    showAppointmentsSheet = true
+                }
+            ),
+            DetailsScorecardItem(
+                kind: .knocks,
+                title: "Knocks",
+                value: "\(prospect.knockHistory.count)",
+                icon: "hand.tap.fill",
+                color: .orange,
+                action: {
+                    ContactScreenHapticsController.shared.lightTap()
+                    ContactScreenSoundController.shared.playSound1()
+                    showKnocksSheet = true
+                }
+            )
+        ]
+    }
+
     private func exportToContacts() {
         let store = CNContactStore()
         

--- a/d2d-studio/views/DetailsScorecardCustomizationView.swift
+++ b/d2d-studio/views/DetailsScorecardCustomizationView.swift
@@ -1,0 +1,304 @@
+//
+//  DetailsScorecardCustomizationView.swift
+//  d2d-studio
+//
+//  Created by Codex on 8/2/26.
+//
+
+import SwiftUI
+
+struct DetailsScorecardItem: Identifiable, Equatable {
+    enum Kind: String {
+        case meetings
+        case knocks
+    }
+
+    let kind: Kind
+    let title: String
+    let value: String
+    let icon: String
+    let color: Color
+    let action: () -> Void
+
+    var id: String { kind.rawValue }
+
+    static func == (lhs: DetailsScorecardItem, rhs: DetailsScorecardItem) -> Bool {
+        lhs.kind == rhs.kind &&
+        lhs.title == rhs.title &&
+        lhs.value == rhs.value &&
+        lhs.icon == rhs.icon
+    }
+}
+
+struct DetailsScorecardCustomizationView: View {
+    let items: [DetailsScorecardItem]
+    let title: String
+
+    @AppStorage private var isMeetingsVisible: Bool
+    @AppStorage private var isKnocksVisible: Bool
+
+    @State private var isEditingScorecards = false
+
+    init(
+        storagePrefix: String,
+        title: String = "Scorecards",
+        items: [DetailsScorecardItem]
+    ) {
+        self.items = items
+        self.title = title
+        _isMeetingsVisible = AppStorage(wrappedValue: true, "\(storagePrefix).scorecards.meetings.visible")
+        _isKnocksVisible = AppStorage(wrappedValue: true, "\(storagePrefix).scorecards.knocks.visible")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+
+            if visibleItems.isEmpty {
+                restorePanel
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            } else {
+                scorecardGrid
+                    .transition(.scale(scale: 0.98).combined(with: .opacity))
+            }
+        }
+        .padding(.horizontal, 10)
+        .animation(.spring(response: 0.3, dampingFraction: 0.82), value: visibleItems.map(\.id))
+        .animation(.spring(response: 0.24, dampingFraction: 0.82), value: isEditingScorecards)
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Label(title, systemImage: "slider.horizontal.3")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            if hiddenItems.isEmpty == false {
+                Button {
+                    restoreAll()
+                } label: {
+                    Image(systemName: "plus.square.on.square")
+                        .font(.system(size: 15, weight: .semibold))
+                        .frame(width: 30, height: 30)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.blue)
+                .background(Color.blue.opacity(0.1), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .accessibilityLabel("Restore All Scorecards")
+            }
+
+            Button {
+                ContactScreenHapticsController.shared.lightTap()
+                isEditingScorecards.toggle()
+            } label: {
+                Image(systemName: isEditingScorecards ? "checkmark.circle.fill" : "wand.and.stars")
+                    .font(.system(size: 15, weight: .semibold))
+                    .frame(width: 30, height: 30)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(isEditingScorecards ? .green : .primary)
+            .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .accessibilityLabel(isEditingScorecards ? "Done Customizing Scorecards" : "Customize Scorecards")
+        }
+    }
+
+    private var scorecardGrid: some View {
+        LazyVGrid(columns: gridColumns, spacing: 12) {
+            ForEach(visibleItems) { item in
+                DetailsCustomizableScorecard(
+                    item: item,
+                    isExpanded: visibleItems.count == 1,
+                    isEditing: isEditingScorecards,
+                    onRemove: {
+                        hide(item.kind)
+                    }
+                )
+                .id(item.id)
+            }
+        }
+    }
+
+    private var restorePanel: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .center, spacing: 10) {
+                Image(systemName: "sparkles.rectangle.stack")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(.blue)
+                    .frame(width: 36, height: 36)
+                    .background(Color.blue.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Scorecards hidden")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+
+                    Text("Bring back either card or restore the full set.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            HStack(spacing: 8) {
+                ForEach(hiddenItems) { item in
+                    Button {
+                        show(item.kind)
+                    } label: {
+                        Label(item.title, systemImage: item.icon)
+                            .font(.caption.weight(.semibold))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.78)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 34)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(item.color)
+                    .background(item.color.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                }
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.white.opacity(0.35), lineWidth: 1)
+        )
+    }
+
+    private var gridColumns: [GridItem] {
+        let visibleCount = visibleItems.count
+        return Array(
+            repeating: GridItem(.flexible(minimum: 0), spacing: 12),
+            count: visibleCount == 1 ? 1 : 2
+        )
+    }
+
+    private var visibleItems: [DetailsScorecardItem] {
+        items.filter { isVisible($0.kind) }
+    }
+
+    private var hiddenItems: [DetailsScorecardItem] {
+        items.filter { !isVisible($0.kind) }
+    }
+
+    private func isVisible(_ kind: DetailsScorecardItem.Kind) -> Bool {
+        switch kind {
+        case .meetings:
+            isMeetingsVisible
+        case .knocks:
+            isKnocksVisible
+        }
+    }
+
+    private func hide(_ kind: DetailsScorecardItem.Kind) {
+        ContactScreenHapticsController.shared.lightTap()
+        setVisible(false, for: kind)
+
+        if visibleItems.count <= 1 {
+            isEditingScorecards = false
+        }
+    }
+
+    private func show(_ kind: DetailsScorecardItem.Kind) {
+        ContactScreenHapticsController.shared.lightTap()
+        ContactScreenSoundController.shared.playSound1()
+        setVisible(true, for: kind)
+        isEditingScorecards = false
+    }
+
+    private func restoreAll() {
+        ContactScreenHapticsController.shared.lightTap()
+        ContactScreenSoundController.shared.playSound1()
+        isMeetingsVisible = true
+        isKnocksVisible = true
+        isEditingScorecards = false
+    }
+
+    private func setVisible(_ isVisible: Bool, for kind: DetailsScorecardItem.Kind) {
+        switch kind {
+        case .meetings:
+            isMeetingsVisible = isVisible
+        case .knocks:
+            isKnocksVisible = isVisible
+        }
+    }
+}
+
+private struct DetailsCustomizableScorecard: View {
+    let item: DetailsScorecardItem
+    let isExpanded: Bool
+    let isEditing: Bool
+    let onRemove: () -> Void
+
+    var body: some View {
+        Button {
+            guard !isEditing else { return }
+            item.action()
+        } label: {
+            HStack(spacing: isExpanded ? 16 : 12) {
+                Image(systemName: item.icon)
+                    .font(.system(size: isExpanded ? 24 : 18, weight: .semibold))
+                    .foregroundStyle(item.color)
+                    .frame(width: isExpanded ? 46 : 32, height: isExpanded ? 46 : 32)
+                    .background(item.color.opacity(0.12), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+                VStack(alignment: .leading, spacing: isExpanded ? 4 : 2) {
+                    Text(item.title)
+                        .font(isExpanded ? .subheadline : .caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+
+                    Text(item.value)
+                        .font(isExpanded ? .largeTitle.weight(.bold) : .title3.weight(.bold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, isExpanded ? 16 : 14)
+            .padding(.vertical, isExpanded ? 14 : 10)
+            .frame(maxWidth: .infinity, minHeight: isExpanded ? 96 : 72, alignment: .leading)
+            .background(Color.white, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(item.color.opacity(isEditing ? 0.55 : 0.25), lineWidth: isEditing ? 1.5 : 1)
+            )
+            .shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)
+            .overlay(alignment: .topTrailing) {
+                if isEditing {
+                    removeButton
+                        .padding(6)
+                        .transition(.scale.combined(with: .opacity))
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(item.title) Scorecard")
+        .accessibilityHint(isEditing ? "Double tap to remove this scorecard" : "Double tap to open details")
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.45)
+                .onEnded { _ in
+                    onRemove()
+                }
+        )
+    }
+
+    private var removeButton: some View {
+        Button {
+            onRemove()
+        } label: {
+            Image(systemName: "minus.circle.fill")
+                .font(.system(size: 20, weight: .semibold))
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.white, .red)
+                .frame(width: 28, height: 28)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Remove \(item.title) Scorecard")
+    }
+}

--- a/d2d-territory-management-service/MapSearchView.swift
+++ b/d2d-territory-management-service/MapSearchView.swift
@@ -63,6 +63,7 @@ struct MapSearchView: View {
     @State private var previousRegionBeforeUserLocationJump: MKCoordinateRegion?
     
     @State private var selectedPlaceID: UUID? = nil
+    @State private var isCustomizingMapScorecards = false
     
     @State private var pendingBulkAdd: PendingBulkAdd?
     
@@ -119,7 +120,7 @@ struct MapSearchView: View {
                 .frame(maxHeight: .infinity)
                 .edgesIgnoringSafeArea(.horizontal)
 
-                ScorecardBar()
+                ScorecardBar(isCustomizingScorecards: $isCustomizingMapScorecards)
 
                 FloatingSearchAndMicButtons(
                     searchText: $searchText,
@@ -617,6 +618,8 @@ struct MapSearchView: View {
     }
 
     private func handleMapTap(at coordinate: CLLocationCoordinate2D) {
+        guard !isCustomizingMapScorecards else { return }
+
         // 🎯 Haptic: instant response
         MapScreenHapticsController.shared.mapTap()
 


### PR DESCRIPTION
This PR aims to give the user for customizability within reason by letting them add or remove the scorecards as they see fit. This can give them time to focus more on knocking for the sake of knocking or get back into analytical knocking when they want. This is the Steve Jobs Apple style of giving the user the illusion of freedom of customizing it. 