### PR TITLE
Implementing A New Scorecard Menu - August '26 Feature Release

### DIFF
--- a/d2d-map-screen-analytics-service/ScorecardBar.swift
+++ b/d2d-map-screen-analytics-service/ScorecardBar.swift
@@ -17,6 +17,8 @@ struct ScorecardBar: View {
     @State private var confirmingRemoval: MapScorecardDefinition?
     @State private var isShowingRestoreTargets = false
 
+    private let maxScorecardCount = 4
+
     var body: some View {
         VStack(spacing: 10) {
             if visibleDefinitions.isEmpty && isShowingRestoreTargets == false {
@@ -43,20 +45,38 @@ struct ScorecardBar: View {
     }
 
     private var scorecardGrid: some View {
-        LazyVGrid(columns: gridColumns, spacing: 12) {
-            ForEach(visibleDefinitions) { definition in
-                scorecardSlot(for: definition)
-                    .frame(maxWidth: .infinity)
+        Group {
+            if visibleDefinitions.count == 3 {
+                VStack(spacing: 12) {
+                    HStack(spacing: 12) {
+                        ForEach(visibleDefinitions.prefix(2)) { definition in
+                            scorecardSlot(for: definition, isExpanded: false)
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+
+                    if let bannerDefinition = visibleDefinitions.last {
+                        scorecardSlot(for: bannerDefinition, isExpanded: true)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+            } else {
+                LazyVGrid(columns: gridColumns, spacing: 12) {
+                    ForEach(visibleDefinitions) { definition in
+                        scorecardSlot(for: definition, isExpanded: visibleDefinitions.count == 1)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
             }
         }
         .frame(maxWidth: visibleDefinitions.count == 1 ? .infinity : 420, alignment: .center)
     }
 
-    private func scorecardSlot(for definition: MapScorecardDefinition) -> some View {
+    private func scorecardSlot(for definition: MapScorecardDefinition, isExpanded: Bool) -> some View {
         VStack(spacing: 8) {
             MapAnalyticsTrackerView(
                 definition: definition,
-                isExpanded: visibleDefinitions.count == 1,
+                isExpanded: isExpanded,
                 isCustomizationActive: isCustomizingScorecards
             )
             .overlay {
@@ -210,6 +230,7 @@ struct ScorecardBar: View {
         MapScorecardSelectorView(
             definitions: MapScorecardDefinition.allCases,
             selectedIDs: Set(selectedIDs),
+            maxSelectionCount: maxScorecardCount,
             onToggle: toggleSelection,
             onRestoreDefaults: restoreDefaultSelection,
             onClose: closeSelector
@@ -296,6 +317,7 @@ struct ScorecardBar: View {
         if selectedIDs.contains(definition.id) {
             setSelection(visibleDefinitions.filter { $0.id != definition.id })
         } else {
+            guard visibleDefinitions.count < maxScorecardCount else { return }
             MapScreenSoundController.shared.playPropertyOpen()
             setSelection(visibleDefinitions + [definition])
         }

--- a/d2d-map-screen-analytics-service/ScorecardBar.swift
+++ b/d2d-map-screen-analytics-service/ScorecardBar.swift
@@ -114,11 +114,11 @@ struct ScorecardBar: View {
             Button {
                 showSelector()
             } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: 14, weight: .bold))
-                    .foregroundStyle(.white)
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 22, weight: .semibold))
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.white, .blue)
                     .frame(width: 30, height: 30)
-                    .background(Color.blue, in: Circle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Choose Map Scorecards")

--- a/d2d-map-screen-analytics-service/ScorecardBar.swift
+++ b/d2d-map-screen-analytics-service/ScorecardBar.swift
@@ -232,6 +232,7 @@ struct ScorecardBar: View {
             selectedIDs: Set(selectedIDs),
             maxSelectionCount: maxScorecardCount,
             onToggle: toggleSelection,
+            onLimitReached: signalScorecardLimitReached,
             onRestoreDefaults: restoreDefaultSelection,
             onClose: closeSelector
         )
@@ -270,6 +271,7 @@ struct ScorecardBar: View {
 
     private func beginEditing(_ definition: MapScorecardDefinition) {
         MapScreenHapticsController.shared.lightTap()
+        MapScreenSoundController.shared.playScorecardSelectorOpen()
         editingScorecard = definition
         confirmingRemoval = nil
         isShowingRestoreTargets = false
@@ -278,12 +280,14 @@ struct ScorecardBar: View {
 
     private func requestRemovalConfirmation(for definition: MapScorecardDefinition) {
         MapScreenHapticsController.shared.lightTap()
+        MapScreenSoundController.shared.playScorecardSelectorOpen()
         confirmingRemoval = definition
         updateCustomizationState()
     }
 
     private func cancelEditing() {
         MapScreenHapticsController.shared.lightTap()
+        MapScreenSoundController.shared.playScorecardSelectorClose()
         editingScorecard = nil
         confirmingRemoval = nil
         updateCustomizationState()
@@ -291,6 +295,7 @@ struct ScorecardBar: View {
 
     private func hide(_ definition: MapScorecardDefinition) {
         MapScreenHapticsController.shared.lightTap()
+        MapScreenSoundController.shared.playScorecardRemoved()
         setSelection(visibleDefinitions.filter { $0.id != definition.id })
         editingScorecard = nil
         confirmingRemoval = nil
@@ -299,6 +304,7 @@ struct ScorecardBar: View {
 
     private func showSelector() {
         MapScreenHapticsController.shared.lightTap()
+        MapScreenSoundController.shared.playScorecardSelectorOpen()
         editingScorecard = nil
         confirmingRemoval = nil
         isShowingRestoreTargets = true
@@ -307,6 +313,7 @@ struct ScorecardBar: View {
 
     private func closeSelector() {
         MapScreenHapticsController.shared.lightTap()
+        MapScreenSoundController.shared.playScorecardSelectorClose()
         isShowingRestoreTargets = false
         updateCustomizationState()
     }
@@ -315,17 +322,26 @@ struct ScorecardBar: View {
         MapScreenHapticsController.shared.lightTap()
 
         if selectedIDs.contains(definition.id) {
+            MapScreenSoundController.shared.playScorecardRemoved()
             setSelection(visibleDefinitions.filter { $0.id != definition.id })
         } else {
-            guard visibleDefinitions.count < maxScorecardCount else { return }
-            MapScreenSoundController.shared.playPropertyOpen()
+            guard visibleDefinitions.count < maxScorecardCount else {
+                signalScorecardLimitReached()
+                return
+            }
+            MapScreenSoundController.shared.playScorecardAdded()
             setSelection(visibleDefinitions + [definition])
         }
     }
 
+    private func signalScorecardLimitReached() {
+        MapScreenHapticsController.shared.bulkAddConfirmed()
+        MapScreenSoundController.shared.playScorecardLimitReached()
+    }
+
     private func restoreDefaultSelection() {
         MapScreenHapticsController.shared.lightTap()
-        MapScreenSoundController.shared.playPropertyOpen()
+        MapScreenSoundController.shared.playScorecardAdded()
         setSelection(MapScorecardDefinition.defaultSelection)
     }
 

--- a/d2d-map-screen-analytics-service/ScorecardBar.swift
+++ b/d2d-map-screen-analytics-service/ScorecardBar.swift
@@ -19,12 +19,17 @@ struct ScorecardBar: View {
 
     var body: some View {
         VStack(spacing: 10) {
-            if visibleDefinitions.isEmpty {
+            if visibleDefinitions.isEmpty && isShowingRestoreTargets == false {
                 emptyScorecardRestoreZone
                     .transition(.opacity)
             } else {
                 scorecardGrid
                     .transition(.scale(scale: 0.98).combined(with: .opacity))
+            }
+
+            if isShowingRestoreTargets {
+                selectorPanel
+                    .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
         .padding(.horizontal, 16)
@@ -86,24 +91,17 @@ struct ScorecardBar: View {
 
     private func editControls(for definition: MapScorecardDefinition) -> some View {
         HStack(spacing: 6) {
-            if hiddenDefinitions.isEmpty == false {
-                Menu {
-                    ForEach(hiddenDefinitions) { hiddenDefinition in
-                        Button {
-                            restore(hiddenDefinition)
-                        } label: {
-                            Label(hiddenDefinition.title, systemImage: hiddenDefinition.icon)
-                        }
-                    }
-                } label: {
-                    Image(systemName: "plus.circle.fill")
-                        .font(.system(size: 22, weight: .semibold))
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(.white, .blue)
-                        .frame(width: 30, height: 30)
-                }
-                .accessibilityLabel("Add Map Scorecard")
+            Button {
+                showSelector()
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 30, height: 30)
+                    .background(Color.blue, in: Circle())
             }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Choose Map Scorecards")
 
             Button {
                 requestRemovalConfirmation(for: definition)
@@ -172,35 +170,15 @@ struct ScorecardBar: View {
     }
 
     private var emptyScorecardRestoreZone: some View {
-        Group {
-            if isShowingRestoreTargets {
-                restoreChooserCard
-                    .transition(.scale(scale: 0.98).combined(with: .opacity))
-            } else {
-                Color.clear
-                    .frame(height: 96)
-                    .frame(maxWidth: .infinity)
-                    .contentShape(Rectangle())
-                    .highPriorityGesture(
-                        LongPressGesture(minimumDuration: 0.5)
-                            .onEnded { _ in
-                                requestRestoreTargets()
-                            }
-                    )
-                    .accessibilityLabel("Show Scorecard Restore Options")
-            }
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    private var restoreChooserCard: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        Button {
+            showSelector()
+        } label: {
             HStack(spacing: 10) {
                 Image(systemName: "plus.circle.fill")
-                    .font(.system(size: 22, weight: .semibold))
+                    .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(.blue)
-                    .frame(width: 40, height: 40)
-                    .background(Color.blue.opacity(0.12), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    .frame(width: 38, height: 38)
+                    .background(Color.blue.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
 
                 Text("Choose scorecards")
                     .font(.subheadline.weight(.semibold))
@@ -208,67 +186,34 @@ struct ScorecardBar: View {
                     .lineLimit(1)
 
                 Spacer(minLength: 0)
-            }
-
-            restoreTargetGrid(for: hiddenDefinitions.isEmpty ? MapScorecardDefinition.allCases : hiddenDefinitions)
-        }
-        .padding(14)
-        .frame(maxWidth: .infinity, minHeight: 118, alignment: .leading)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(Color.blue.opacity(0.24), lineWidth: 1)
-        )
-        .shadow(color: Color.black.opacity(0.16), radius: 14, x: 0, y: 8)
-    }
-
-    private func restoreTargetGrid(for definitions: [MapScorecardDefinition]) -> some View {
-        LazyVGrid(columns: Array(repeating: GridItem(.flexible(minimum: 0), spacing: 10), count: 2), spacing: 10) {
-            ForEach(definitions) { definition in
-                restoreTarget(for: definition)
-            }
-        }
-    }
-
-    private func restoreTarget(for definition: MapScorecardDefinition) -> some View {
-        Button {
-            restore(definition)
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: definition.icon)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(definition.color)
-                    .frame(width: 24, height: 24)
-                    .background(definition.color.opacity(0.12), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
-
-                Text(definition.title)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.72)
-
-                Spacer(minLength: 0)
 
                 Image(systemName: "plus")
-                    .font(.system(size: 12, weight: .bold))
+                    .font(.system(size: 13, weight: .bold))
                     .foregroundStyle(.white)
-                    .frame(width: 22, height: 22)
-                    .background(definition.color, in: Circle())
+                    .frame(width: 26, height: 26)
+                    .background(Color.blue, in: Circle())
             }
-            .padding(.horizontal, 10)
-            .frame(maxWidth: .infinity)
-            .frame(height: 46)
-            .background(definition.color.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .padding(12)
+            .frame(maxWidth: 430, minHeight: 72, alignment: .leading)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
             .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(
-                        definition.color,
-                        style: StrokeStyle(lineWidth: 1.6, dash: [6, 5])
-                    )
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.white.opacity(0.35), lineWidth: 1)
             )
+            .shadow(color: Color.black.opacity(0.16), radius: 14, x: 0, y: 8)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Add \(definition.title) Scorecard")
+        .accessibilityLabel("Choose Map Scorecards")
+    }
+
+    private var selectorPanel: some View {
+        MapScorecardSelectorView(
+            definitions: MapScorecardDefinition.allCases,
+            selectedIDs: Set(selectedIDs),
+            onToggle: toggleSelection,
+            onRestoreDefaults: restoreDefaultSelection,
+            onClose: closeSelector
+        )
     }
 
     private var gridColumns: [GridItem] {
@@ -278,11 +223,6 @@ struct ScorecardBar: View {
 
     private var visibleDefinitions: [MapScorecardDefinition] {
         selectedIDs.compactMap { MapScorecardDefinition.definition(for: $0) }
-    }
-
-    private var hiddenDefinitions: [MapScorecardDefinition] {
-        let selected = Set(selectedIDs)
-        return MapScorecardDefinition.allCases.filter { selected.contains($0.id) == false }
     }
 
     private var selectedIDs: [String] {
@@ -336,24 +276,35 @@ struct ScorecardBar: View {
         updateCustomizationState()
     }
 
-    private func requestRestoreTargets() {
+    private func showSelector() {
         MapScreenHapticsController.shared.lightTap()
+        editingScorecard = nil
+        confirmingRemoval = nil
         isShowingRestoreTargets = true
         updateCustomizationState()
     }
 
-    private func restore(_ definition: MapScorecardDefinition) {
+    private func closeSelector() {
         MapScreenHapticsController.shared.lightTap()
-        MapScreenSoundController.shared.playPropertyOpen()
-
-        var nextSelection = visibleDefinitions.filter { $0.id != definition.id }
-        nextSelection.append(definition)
-        setSelection(nextSelection)
-
-        editingScorecard = nil
-        confirmingRemoval = nil
         isShowingRestoreTargets = false
         updateCustomizationState()
+    }
+
+    private func toggleSelection(_ definition: MapScorecardDefinition) {
+        MapScreenHapticsController.shared.lightTap()
+
+        if selectedIDs.contains(definition.id) {
+            setSelection(visibleDefinitions.filter { $0.id != definition.id })
+        } else {
+            MapScreenSoundController.shared.playPropertyOpen()
+            setSelection(visibleDefinitions + [definition])
+        }
+    }
+
+    private func restoreDefaultSelection() {
+        MapScreenHapticsController.shared.lightTap()
+        MapScreenSoundController.shared.playPropertyOpen()
+        setSelection(MapScorecardDefinition.defaultSelection)
     }
 
     private func setSelection(_ definitions: [MapScorecardDefinition]) {

--- a/d2d-map-screen-analytics-service/views/MapScorecardSelectorView.swift
+++ b/d2d-map-screen-analytics-service/views/MapScorecardSelectorView.swift
@@ -12,6 +12,7 @@ struct MapScorecardSelectorView: View {
     let selectedIDs: Set<String>
     let maxSelectionCount: Int
     let onToggle: (MapScorecardDefinition) -> Void
+    let onLimitReached: () -> Void
     let onRestoreDefaults: () -> Void
     let onClose: () -> Void
 
@@ -33,7 +34,8 @@ struct MapScorecardSelectorView: View {
                         isDisabled: isSelectionFull && isSelected == false,
                         onToggle: {
                             onToggle(definition)
-                        }
+                        },
+                        onLimitReached: onLimitReached
                     )
                 }
             }
@@ -127,10 +129,15 @@ private struct MapScorecardSelectorTile: View {
     let isSelected: Bool
     let isDisabled: Bool
     let onToggle: () -> Void
+    let onLimitReached: () -> Void
 
     var body: some View {
         Button {
-            onToggle()
+            if isDisabled {
+                onLimitReached()
+            } else {
+                onToggle()
+            }
         } label: {
             VStack(alignment: .leading, spacing: 10) {
                 HStack(alignment: .top, spacing: 6) {
@@ -170,7 +177,6 @@ private struct MapScorecardSelectorTile: View {
             )
         }
         .buttonStyle(.plain)
-        .disabled(isDisabled)
         .opacity(isDisabled ? 0.48 : 1)
         .accessibilityLabel(accessibilityLabel)
     }

--- a/d2d-map-screen-analytics-service/views/MapScorecardSelectorView.swift
+++ b/d2d-map-screen-analytics-service/views/MapScorecardSelectorView.swift
@@ -1,0 +1,184 @@
+//
+//  MapScorecardSelectorView.swift
+//  d2d-studio
+//
+//  Created by Codex on 8/3/26.
+//
+
+import SwiftUI
+
+struct MapScorecardSelectorView: View {
+    let definitions: [MapScorecardDefinition]
+    let selectedIDs: Set<String>
+    let onToggle: (MapScorecardDefinition) -> Void
+    let onRestoreDefaults: () -> Void
+    let onClose: () -> Void
+
+    private let columns = Array(
+        repeating: GridItem(.flexible(minimum: 0), spacing: 10),
+        count: 3
+    )
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+
+            LazyVGrid(columns: columns, spacing: 10) {
+                ForEach(definitions) { definition in
+                    MapScorecardSelectorTile(
+                        definition: definition,
+                        isSelected: selectedIDs.contains(definition.id),
+                        onToggle: {
+                            onToggle(definition)
+                        }
+                    )
+                }
+            }
+
+            footer
+        }
+        .padding(14)
+        .frame(maxWidth: 430, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.white.opacity(0.35), lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.18), radius: 16, x: 0, y: 8)
+        .accessibilityElement(children: .contain)
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "rectangle.grid.3x2.fill")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(.blue)
+                .frame(width: 34, height: 34)
+                .background(Color.blue.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Scorecards")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+
+                Text("\(selectedIDs.count) active")
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 0)
+
+            Button {
+                onClose()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 30, height: 30)
+                    .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close Scorecard Selector")
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            Button {
+                onRestoreDefaults()
+            } label: {
+                Label("Defaults", systemImage: "arrow.counterclockwise")
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.82)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 34)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.blue)
+            .background(Color.blue.opacity(0.1), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+            Button {
+                onClose()
+            } label: {
+                Label("Done", systemImage: "checkmark")
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.82)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 34)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.white)
+            .background(Color.primary, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+    }
+}
+
+private struct MapScorecardSelectorTile: View {
+    let definition: MapScorecardDefinition
+    let isSelected: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button {
+            onToggle()
+        } label: {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: definition.icon)
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(definition.color)
+                        .frame(width: 32, height: 32)
+                        .background(definition.color.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                    Spacer(minLength: 0)
+
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "plus.circle")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(isSelected ? definition.color : .secondary)
+                        .frame(width: 22, height: 22)
+                }
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(definition.period.selectorTitle)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+
+                    Text(definition.metric.noun)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.78)
+                }
+            }
+            .padding(10)
+            .frame(maxWidth: .infinity, minHeight: 94, alignment: .leading)
+            .background(tileBackground, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(isSelected ? definition.color.opacity(0.75) : Color.white.opacity(0.28), lineWidth: isSelected ? 1.5 : 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(isSelected ? "Remove" : "Add") \(definition.title) Scorecard")
+    }
+
+    private var tileBackground: Color {
+        isSelected ? definition.color.opacity(0.12) : Color(.secondarySystemBackground).opacity(0.82)
+    }
+}
+
+private extension MapScorecardPeriod {
+    var selectorTitle: String {
+        switch self {
+        case .daily:
+            "Today"
+        case .weekly:
+            "Week"
+        case .monthly:
+            "Month"
+        }
+    }
+}

--- a/d2d-map-screen-analytics-service/views/MapScorecardSelectorView.swift
+++ b/d2d-map-screen-analytics-service/views/MapScorecardSelectorView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct MapScorecardSelectorView: View {
     let definitions: [MapScorecardDefinition]
     let selectedIDs: Set<String>
+    let maxSelectionCount: Int
     let onToggle: (MapScorecardDefinition) -> Void
     let onRestoreDefaults: () -> Void
     let onClose: () -> Void
@@ -25,9 +26,11 @@ struct MapScorecardSelectorView: View {
 
             LazyVGrid(columns: columns, spacing: 10) {
                 ForEach(definitions) { definition in
+                    let isSelected = selectedIDs.contains(definition.id)
                     MapScorecardSelectorTile(
                         definition: definition,
-                        isSelected: selectedIDs.contains(definition.id),
+                        isSelected: isSelected,
+                        isDisabled: isSelectionFull && isSelected == false,
                         onToggle: {
                             onToggle(definition)
                         }
@@ -61,7 +64,7 @@ struct MapScorecardSelectorView: View {
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.primary)
 
-                Text("\(selectedIDs.count) active")
+                Text("\(selectedIDs.count) of \(maxSelectionCount) active")
                     .font(.caption2.weight(.medium))
                     .foregroundStyle(.secondary)
             }
@@ -80,6 +83,10 @@ struct MapScorecardSelectorView: View {
             .buttonStyle(.plain)
             .accessibilityLabel("Close Scorecard Selector")
         }
+    }
+
+    private var isSelectionFull: Bool {
+        selectedIDs.count >= maxSelectionCount
     }
 
     private var footer: some View {
@@ -118,6 +125,7 @@ struct MapScorecardSelectorView: View {
 private struct MapScorecardSelectorTile: View {
     let definition: MapScorecardDefinition
     let isSelected: Bool
+    let isDisabled: Bool
     let onToggle: () -> Void
 
     var body: some View {
@@ -134,9 +142,9 @@ private struct MapScorecardSelectorTile: View {
 
                     Spacer(minLength: 0)
 
-                    Image(systemName: isSelected ? "checkmark.circle.fill" : "plus.circle")
+                    Image(systemName: statusIcon)
                         .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(isSelected ? definition.color : .secondary)
+                        .foregroundStyle(statusColor)
                         .frame(width: 22, height: 22)
                 }
 
@@ -162,11 +170,29 @@ private struct MapScorecardSelectorTile: View {
             )
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("\(isSelected ? "Remove" : "Add") \(definition.title) Scorecard")
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.48 : 1)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var statusIcon: String {
+        if isSelected { return "checkmark.circle.fill" }
+        return isDisabled ? "lock.circle" : "plus.circle"
+    }
+
+    private var statusColor: Color {
+        if isSelected { return definition.color }
+        return isDisabled ? .secondary.opacity(0.72) : .secondary
     }
 
     private var tileBackground: Color {
-        isSelected ? definition.color.opacity(0.12) : Color(.secondarySystemBackground).opacity(0.82)
+        if isSelected { return definition.color.opacity(0.12) }
+        return Color(.secondarySystemBackground).opacity(isDisabled ? 0.52 : 0.82)
+    }
+
+    private var accessibilityLabel: String {
+        if isDisabled { return "Maximum Scorecards Reached" }
+        return "\(isSelected ? "Remove" : "Add") \(definition.title) Scorecard"
     }
 }
 

--- a/d2d-territory-management-service/controllers/MapScreenSoundController.swift
+++ b/d2d-territory-management-service/controllers/MapScreenSoundController.swift
@@ -24,4 +24,24 @@ final class MapScreenSoundController {
     func playPropertyAdded() {
         AudioServicesPlaySystemSound(1104) // rewarding success tap
     }
+
+    func playScorecardSelectorOpen() {
+        AudioServicesPlaySystemSound(1104)
+    }
+
+    func playScorecardSelectorClose() {
+        AudioServicesPlaySystemSound(1157)
+    }
+
+    func playScorecardAdded() {
+        AudioServicesPlaySystemSound(1104)
+    }
+
+    func playScorecardRemoved() {
+        AudioServicesPlaySystemSound(1155)
+    }
+
+    func playScorecardLimitReached() {
+        AudioServicesPlaySystemSound(1053)
+    }
 }


### PR DESCRIPTION
This PR upgrades the map scorecard customization experience from a basic popup into a modern CRM-style selector with a clean 3-column grid, clear icons, active states, and quick default restoration. Users can now manage all available map scorecards from one reusable selector instead of only adding hidden cards through a menu. The map screen now limits active scorecards to 4 total, preserving a clean 2x2 maximum layout. When exactly 3 scorecards are active, the third card renders as a full-width banner for better visual balance. The edit-mode add button now visually matches the remove control, using the same size and style with a blue plus treatment. The new interactions include dedicated haptics and scorecard-specific sounds for opening, closing, adding, removing, restoring defaults, and hitting the max-scorecard limit.