### PR TITLE
Implementing A New Trip Details Screen - August '26 Vanity Release

### DIFF
--- a/d2d-studio.xcodeproj/project.pbxproj
+++ b/d2d-studio.xcodeproj/project.pbxproj
@@ -707,7 +707,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;
@@ -757,7 +757,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;

--- a/d2d-trip-analytics-service/views/DailyMilesChartView.swift
+++ b/d2d-trip-analytics-service/views/DailyMilesChartView.swift
@@ -9,56 +9,74 @@ import SwiftUI
 
 struct DailyMilesChartView: View {
     let segments: [DailyMilesSegment]
-    
-    // Fixed chart height
-    private let chartHeight: CGFloat = 100
-    
+
+    private let chartHeight: CGFloat = 112
+    private let barWidth: CGFloat = 28
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            // Total miles headline
+        VStack(alignment: .center, spacing: 14) {
             let total = segments.reduce(0) { $0 + $1.miles }
-            Text("Total miles today: \(total, specifier: "%.1f")")
-                .font(.headline)
-                .bold()
-            
-            // Horizontal bars
-            HStack(spacing: 12) {
+
+            VStack(spacing: 2) {
+                Text("Today")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
+
+                Text("\(total, specifier: "%.1f") miles")
+                    .font(.title3.weight(.bold))
+                    .monospacedDigit()
+            }
+            .frame(maxWidth: .infinity)
+
+            HStack(alignment: .bottom, spacing: 18) {
                 let maxMiles = segments.map { $0.miles }.max() ?? 1
                 ForEach(segments, id: \.period) { segment in
-                    VStack {
+                    VStack(spacing: 8) {
+                        Text("\(segment.miles, specifier: "%.1f")")
+                            .font(.caption2.weight(.semibold))
+                            .monospacedDigit()
+                            .foregroundColor(.secondary)
+
                         ZStack(alignment: .bottom) {
                             Capsule()
-                                .fill(Color.gray.opacity(0.2))
-                                .frame(width: 20, height: chartHeight)
-                            
+                                .fill(Color(.tertiarySystemFill))
+                                .frame(width: barWidth, height: chartHeight)
+
                             Capsule()
                                 .fill(color(for: segment.period))
                                 .frame(
-                                    width: 20,
+                                    width: barWidth,
                                     height: normalizedHeight(for: segment.miles, maxMiles: maxMiles)
                                 )
                         }
-                        Text(segment.period.prefix(1)) // M, A, E
-                            .font(.caption2)
+
+                        Text(segment.period)
+                            .font(.caption2.weight(.medium))
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
                     }
+                    .frame(maxWidth: .infinity)
                 }
             }
+            .frame(maxWidth: .infinity)
         }
-        .padding()
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+        .frame(maxWidth: .infinity)
         .background(
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(Color(.secondarySystemBackground))
         )
         .padding(.horizontal)
     }
-    
+
     func normalizedHeight(for miles: Double, maxMiles: Double) -> CGFloat {
-        // Prevent division by zero
         guard maxMiles > 0 else { return 0 }
-        // Scale proportionally within chartHeight
-        return CGFloat(miles / maxMiles) * chartHeight
+        guard miles > 0 else { return 4 }
+        return max(8, CGFloat(miles / maxMiles) * chartHeight)
     }
-    
+
     func color(for period: String) -> Color {
         switch period {
         case "Morning": return .blue

--- a/d2d-trip-analytics-service/views/MonthlyMilesChartView.swift
+++ b/d2d-trip-analytics-service/views/MonthlyMilesChartView.swift
@@ -9,40 +9,60 @@ import SwiftUI
 
 struct MonthlyMilesChartView: View {
     let segments: [MonthlyMilesSegment]
-    private let chartHeight: CGFloat = 100
+    private let chartHeight: CGFloat = 112
+    private let barWidth: CGFloat = 28
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .center, spacing: 14) {
             let total = segments.reduce(0) { $0 + $1.miles }
-            Text("Total miles this month: \(total, specifier: "%.1f")")
-                .font(.headline)
-                .bold()
 
-            HStack(spacing: 12) {
+            VStack(spacing: 2) {
+                Text("This Month")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
+
+                Text("\(total, specifier: "%.1f") miles")
+                    .font(.title3.weight(.bold))
+                    .monospacedDigit()
+            }
+            .frame(maxWidth: .infinity)
+
+            HStack(alignment: .bottom, spacing: 18) {
                 let maxMiles = segments.map { $0.miles }.max() ?? 1
                 ForEach(segments) { segment in
-                    VStack {
+                    VStack(spacing: 8) {
+                        Text("\(segment.miles, specifier: "%.1f")")
+                            .font(.caption2.weight(.semibold))
+                            .monospacedDigit()
+                            .foregroundColor(.secondary)
+
                         ZStack(alignment: .bottom) {
                             Capsule()
-                                .fill(Color.gray.opacity(0.2))
-                                .frame(width: 20, height: chartHeight)
+                                .fill(Color(.tertiarySystemFill))
+                                .frame(width: barWidth, height: chartHeight)
 
                             Capsule()
                                 .fill(Color.green)
                                 .frame(
-                                    width: 20,
+                                    width: barWidth,
                                     height: normalizedHeight(for: segment.miles, maxMiles: maxMiles)
                                 )
                         }
-                        Text(segment.weekLabel) // W1, W2...
-                            .font(.caption2)
+
+                        Text(segment.weekLabel)
+                            .font(.caption2.weight(.medium))
+                            .foregroundColor(.secondary)
                     }
+                    .frame(maxWidth: .infinity)
                 }
             }
+            .frame(maxWidth: .infinity)
         }
-        .padding()
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+        .frame(maxWidth: .infinity)
         .background(
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(Color(.secondarySystemBackground))
         )
         .padding(.horizontal)
@@ -50,6 +70,7 @@ struct MonthlyMilesChartView: View {
 
     private func normalizedHeight(for miles: Double, maxMiles: Double) -> CGFloat {
         guard maxMiles > 0 else { return 0 }
-        return CGFloat(miles / maxMiles) * chartHeight
+        guard miles > 0 else { return 4 }
+        return max(8, CGFloat(miles / maxMiles) * chartHeight)
     }
 }

--- a/d2d-trip-analytics-service/views/WeeklyMilesChartView.swift
+++ b/d2d-trip-analytics-service/views/WeeklyMilesChartView.swift
@@ -9,40 +9,60 @@ import SwiftUI
 
 struct WeeklyMilesChartView: View {
     let segments: [WeeklyMilesSegment]
-    private let chartHeight: CGFloat = 100
+    private let chartHeight: CGFloat = 112
+    private let barWidth: CGFloat = 24
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .center, spacing: 14) {
             let total = segments.reduce(0) { $0 + $1.miles }
-            Text("Total miles this week: \(total, specifier: "%.1f")")
-                .font(.headline)
-                .bold()
 
-            HStack(spacing: 12) {
+            VStack(spacing: 2) {
+                Text("This Week")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
+
+                Text("\(total, specifier: "%.1f") miles")
+                    .font(.title3.weight(.bold))
+                    .monospacedDigit()
+            }
+            .frame(maxWidth: .infinity)
+
+            HStack(alignment: .bottom, spacing: 10) {
                 let maxMiles = segments.map { $0.miles }.max() ?? 1
                 ForEach(segments) { segment in
-                    VStack {
+                    VStack(spacing: 8) {
+                        Text("\(segment.miles, specifier: "%.1f")")
+                            .font(.caption2.weight(.semibold))
+                            .monospacedDigit()
+                            .foregroundColor(.secondary)
+
                         ZStack(alignment: .bottom) {
                             Capsule()
-                                .fill(Color.gray.opacity(0.2))
-                                .frame(width: 20, height: chartHeight)
-                            
+                                .fill(Color(.tertiarySystemFill))
+                                .frame(width: barWidth, height: chartHeight)
+
                             Capsule()
                                 .fill(Color.blue)
                                 .frame(
-                                    width: 20,
+                                    width: barWidth,
                                     height: normalizedHeight(for: segment.miles, maxMiles: maxMiles)
                                 )
                         }
-                        Text(segment.day.prefix(3)) // Mon, Tue...
-                            .font(.caption2)
+
+                        Text(segment.day.prefix(3))
+                            .font(.caption2.weight(.medium))
+                            .foregroundColor(.secondary)
                     }
+                    .frame(maxWidth: .infinity)
                 }
             }
+            .frame(maxWidth: .infinity)
         }
-        .padding()
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+        .frame(maxWidth: .infinity)
         .background(
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(Color(.secondarySystemBackground))
         )
         .padding(.horizontal)
@@ -50,6 +70,7 @@ struct WeeklyMilesChartView: View {
 
     private func normalizedHeight(for miles: Double, maxMiles: Double) -> CGFloat {
         guard maxMiles > 0 else { return 0 }
-        return CGFloat(miles / maxMiles) * chartHeight
+        guard miles > 0 else { return 4 }
+        return max(8, CGFloat(miles / maxMiles) * chartHeight)
     }
 }

--- a/d2d-trip-analytics-service/views/YearlyMilesChartView.swift
+++ b/d2d-trip-analytics-service/views/YearlyMilesChartView.swift
@@ -9,49 +9,73 @@ import SwiftUI
 
 struct YearlyMilesChartView: View {
     let segments: [YearlyMilesSegment]
-    
-    private let chartHeight: CGFloat = 100
+
+    private let chartHeight: CGFloat = 112
+    private let barWidth: CGFloat = 18
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .center, spacing: 14) {
             let total = segments.reduce(0) { $0 + $1.miles }
-            Text("Total miles this year: \(total, specifier: "%.1f")")
-                .font(.headline)
-                .bold()
-            
-            HStack(spacing: 6) {
+
+            VStack(spacing: 2) {
+                Text("This Year")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
+
+                Text("\(total, specifier: "%.1f") miles")
+                    .font(.title3.weight(.bold))
+                    .monospacedDigit()
+            }
+            .frame(maxWidth: .infinity)
+
+            HStack(alignment: .bottom, spacing: 4) {
                 let maxMiles = segments.map { $0.miles }.max() ?? 1
                 ForEach(segments) { segment in
-                    VStack {
+                    VStack(spacing: 8) {
+                        Text("\(segment.miles, specifier: "%.0f")")
+                            .font(.system(size: 9, weight: .semibold))
+                            .monospacedDigit()
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.7)
+
                         ZStack(alignment: .bottom) {
                             Capsule()
-                                .fill(Color.gray.opacity(0.2))
-                                .frame(width: 20, height: chartHeight)
-                            
+                                .fill(Color(.tertiarySystemFill))
+                                .frame(width: barWidth, height: chartHeight)
+
                             Capsule()
                                 .fill(Color.green)
                                 .frame(
-                                    width: 20,
+                                    width: barWidth,
                                     height: normalizedHeight(for: segment.miles, maxMiles: maxMiles)
                                 )
                         }
-                        
+
                         Text(segment.month.prefix(3))
-                            .font(.caption2)
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.7)
                     }
+                    .frame(maxWidth: .infinity)
                 }
             }
+            .frame(maxWidth: .infinity)
         }
-        .padding()
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+        .frame(maxWidth: .infinity)
         .background(
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(Color(.secondarySystemBackground))
         )
         .padding(.horizontal)
     }
-    
+
     func normalizedHeight(for miles: Double, maxMiles: Double) -> CGFloat {
         guard maxMiles > 0 else { return 0 }
-        return CGFloat(miles / maxMiles) * chartHeight
+        guard miles > 0 else { return 4 }
+        return max(8, CGFloat(miles / maxMiles) * chartHeight)
     }
 }

--- a/d2d-trip-manager-service/TripsSectionView.swift
+++ b/d2d-trip-manager-service/TripsSectionView.swift
@@ -190,7 +190,7 @@ struct TripsSectionView: View {
         }
         .sheet(item: $selectedTrip) { trip in
             TripDetailsView(trip: trip)
-                .presentationDetents([.fraction(0.75)])
+                .presentationDetents([.fraction(0.82)])
                 .presentationDragIndicator(.visible)
         }
         // NEW: bulk delete confirmation

--- a/d2d-trip-manager-service/views/TripDetailsView.swift
+++ b/d2d-trip-manager-service/views/TripDetailsView.swift
@@ -15,20 +15,21 @@ struct TripDetailsView: View {
 
     @State private var startAddress: String
     @State private var endAddress: String
-    @State private var miles: String
     @State private var date: Date
 
     @FocusState private var focusedField: Field?
     @StateObject private var searchVM = SearchCompleterViewModel()
 
     @State private var showDeleteConfirmation = false
+    @State private var showDateEditor = false
+    @State private var showTimeEditor = false
+    @State private var isSaving = false
 
     // MARK: - Init
     init(trip: Trip) {
         self.trip = trip
         _startAddress = State(initialValue: trip.startAddress)
         _endAddress = State(initialValue: trip.endAddress)
-        _miles = State(initialValue: String(format: "%.1f", trip.miles))
         _date = State(initialValue: trip.date)
     }
 
@@ -39,141 +40,369 @@ struct TripDetailsView: View {
         date != trip.date
     }
 
+    private var hasUnsavedAddressEdits: Bool {
+        startAddress.trimmingCharacters(in: .whitespacesAndNewlines) != trip.startAddress.trimmingCharacters(in: .whitespacesAndNewlines) ||
+        endAddress.trimmingCharacters(in: .whitespacesAndNewlines) != trip.endAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isEditingAddress: Bool {
+        focusedField != nil || hasUnsavedAddressEdits
+    }
+
+    private var canSave: Bool {
+        hasUnsavedEdits &&
+        !isSaving &&
+        !startAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !endAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     var body: some View {
-        ZStack {
-            NavigationStack {
-                Form {
-                    
-                    RouteMapView(startAddress: startAddress, endAddress: endAddress)
-                        .frame(height: 100)
-                        .cornerRadius(12)
-                        .padding(.vertical, 8)
-                    
-                    Section(header: Text("Trip Details")) {
-                        TripAddressFieldView(
-                            iconName: "circle",
-                            placeholder: "Start Address",
-                            iconColor: .blue,
-                            addressText: $startAddress,
-                            focusedField: $focusedField,
-                            fieldType: .start,
-                            searchVM: searchVM
-                        )
-
-                        TripAddressFieldView(
-                            iconName: "mappin.circle.fill",
-                            placeholder: "End Address",
-                            iconColor: .red,
-                            addressText: $endAddress,
-                            focusedField: $focusedField,
-                            fieldType: .end,
-                            searchVM: searchVM
-                        )
-
-                        HStack {
-                            Image(systemName: "calendar")
-                                .foregroundColor(.blue)
-                            DatePicker("Trip Date & Time", selection: $date, displayedComponents: [.date, .hourAndMinute])
-                                .labelsHidden()
-                        }
-                        
-                    }
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    routePreview
+                    tripSummary
+                    routeEditor
                 }
-                .navigationTitle("Trip Details")
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    // Back button top-left
-                    ToolbarItem(placement: .navigationBarLeading) {
-                        Button {
-                            
-                            // Haptics + sound
-                            TripManagerHapticsController.shared.lightTap()
-                            TripManagerSoundController.shared.playSound1()
-                            
-                            dismiss()
-                            
-                        } label: {
-                            Label("Back", systemImage: "chevron.left")
-                        }
-                    }
-
-                    // Save button top-right (conditional)
-                    if hasUnsavedEdits {
-                        ToolbarItem(placement: .navigationBarTrailing) {
-                            Button("Save Changes") {
-                                Task {
-                                    let distance = await TripsController.shared.calculateMiles(
-                                        from: startAddress,
-                                        to: endAddress
-                                    )
-                                    await MainActor.run {
-                                        trip.startAddress = startAddress
-                                        trip.endAddress = endAddress
-                                        trip.miles = distance
-                                        trip.date = date
-                                        try? context.save()
-                                        dismiss()
-                                    }
-                                }
-                            }
-                            .buttonStyle(.borderedProminent)
-                        }
-                    }
-                }
+                .padding(.horizontal, 18)
+                .padding(.top, 12)
+                .padding(.bottom, 130)
             }
-
-            // Floating circular trash button (bottom-left)
-            VStack {
-                Spacer()
-                HStack {
-                    Button(role: .destructive) {
-                        
-                        // Haptics + sound
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle("Trip Manager")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
                         TripManagerHapticsController.shared.lightTap()
                         TripManagerSoundController.shared.playSound1()
-                        
-                        showDeleteConfirmation = true
-                        
+                        dismiss()
                     } label: {
-                        Image(systemName: "trash.fill")
-                            .font(.system(size: 22, weight: .semibold))
-                            .foregroundColor(.white)
-                            .frame(width: 50, height: 50)
-                            .background(Circle().fill(Color.red))
-                            .shadow(radius: 4)
+                        Image(systemName: "chevron.left")
                     }
-                    .buttonStyle(.plain)
-                    .padding(.leading, 20)
-                    .padding(.bottom, 30)
-
-                    Spacer()
                 }
             }
+            .safeAreaInset(edge: .bottom) {
+                bottomActions
+            }
         }
-        // Delete confirmation alert
         .alert("Delete Trip?", isPresented: $showDeleteConfirmation) {
             Button("Delete", role: .destructive) {
-                
-                // Haptics + sound for deletion
                 TripManagerHapticsController.shared.mediumTap()
                 TripManagerSoundController.shared.playSound1()
-                
+
                 context.delete(trip)
-                
                 try? context.save()
-                
                 dismiss()
-                
             }
             Button("Cancel", role: .cancel) {
-                
-                // Haptics + sound for cancel
                 TripManagerHapticsController.shared.lightTap()
                 TripManagerSoundController.shared.playSound1()
-                
             }
         } message: {
             Text("This trip will be permanently deleted.")
+        }
+        .sheet(isPresented: $showDateEditor) {
+            dateEditorSheet(
+                title: "Edit Date",
+                displayedComponents: [.date],
+                detent: .fraction(0.34)
+            )
+        }
+        .sheet(isPresented: $showTimeEditor) {
+            dateEditorSheet(
+                title: "Edit Time",
+                displayedComponents: [.hourAndMinute],
+                detent: .fraction(0.28)
+            )
+        }
+    }
+
+    private var routePreview: some View {
+        Button {
+            TripManagerHapticsController.shared.lightTap()
+            TripManagerSoundController.shared.playSound1()
+            openTripInAppleMaps()
+        } label: {
+            ZStack(alignment: .bottomLeading) {
+                RouteMapView(startAddress: startAddress, endAddress: endAddress)
+                    .frame(height: 210)
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                LinearGradient(
+                    colors: [.clear, .black.opacity(0.62)],
+                    startPoint: .center,
+                    endPoint: .bottom
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("\(trip.miles, specifier: "%.1f") miles", systemImage: "car.fill")
+                        .font(.headline)
+                        .foregroundColor(.white)
+
+                    Text("Open route in Apple Maps")
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.86))
+                }
+                .padding(16)
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.black.opacity(0.06), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var tripSummary: some View {
+        HStack(spacing: 10) {
+            metricTile(title: "Distance", value: String(format: "%.1f", trip.miles), unit: "mi", iconName: "gauge.with.dots.needle.33percent")
+            editableMetricTile(
+                title: "Date",
+                value: date.formatted(.dateTime.month(.abbreviated).day()),
+                unit: date.formatted(.dateTime.year()),
+                iconName: "calendar"
+            ) {
+                TripManagerHapticsController.shared.lightTap()
+                TripManagerSoundController.shared.playSound1()
+                showDateEditor = true
+            }
+            editableMetricTile(
+                title: "Time",
+                value: date.formatted(.dateTime.hour().minute()),
+                unit: "",
+                iconName: "clock"
+            ) {
+                TripManagerHapticsController.shared.lightTap()
+                TripManagerSoundController.shared.playSound1()
+                showTimeEditor = true
+            }
+        }
+    }
+
+    private var routeEditor: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            sectionHeader("Route")
+
+            VStack(spacing: 0) {
+                TripAddressFieldView(
+                    iconName: "circle.fill",
+                    placeholder: "Start Address",
+                    iconColor: .green,
+                    addressText: $startAddress,
+                    focusedField: $focusedField,
+                    fieldType: .start,
+                    searchVM: searchVM
+                )
+                .padding(.horizontal, 14)
+                .padding(.vertical, 12)
+                .simultaneousGesture(TapGesture().onEnded {
+                    TripManagerHapticsController.shared.lightTap()
+                    TripManagerSoundController.shared.playSound1()
+                })
+
+                Divider()
+                    .padding(.leading, 42)
+
+                TripAddressFieldView(
+                    iconName: "mappin.circle.fill",
+                    placeholder: "End Address",
+                    iconColor: .red,
+                    addressText: $endAddress,
+                    focusedField: $focusedField,
+                    fieldType: .end,
+                    searchVM: searchVM
+                )
+                .padding(.horizontal, 14)
+                .padding(.vertical, 12)
+                .simultaneousGesture(TapGesture().onEnded {
+                    TripManagerHapticsController.shared.lightTap()
+                    TripManagerSoundController.shared.playSound1()
+                })
+            }
+            .background(cardBackground)
+        }
+    }
+
+    private var bottomActions: some View {
+        HStack(spacing: 12) {
+            if isEditingAddress {
+                Button {
+                    revertAddressEdits()
+                } label: {
+                    Image(systemName: "arrow.uturn.backward")
+                        .font(.headline)
+                        .frame(width: 48, height: 48)
+                }
+                .buttonStyle(.bordered)
+                .tint(.orange)
+            } else {
+                Button(role: .destructive) {
+                    TripManagerHapticsController.shared.lightTap()
+                    TripManagerSoundController.shared.playSound1()
+                    showDeleteConfirmation = true
+                } label: {
+                    Image(systemName: "trash.fill")
+                        .font(.headline)
+                        .frame(width: 48, height: 48)
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+            }
+
+            Button {
+                saveTrip()
+            } label: {
+                HStack(spacing: 8) {
+                    if isSaving {
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        Image(systemName: "checkmark")
+                    }
+
+                    Text(hasUnsavedEdits ? "Save Changes" : "Saved")
+                        .fontWeight(.semibold)
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 48)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!canSave)
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 12)
+        .padding(.bottom, 8)
+        .background(.ultraThinMaterial)
+        .animation(.spring(response: 0.25, dampingFraction: 0.88), value: isEditingAddress)
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(Color(.systemBackground))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.black.opacity(0.05), lineWidth: 1)
+            )
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.subheadline.weight(.semibold))
+            .foregroundColor(.secondary)
+    }
+
+    private func metricTile(title: String, value: String, unit: String, iconName: String) -> some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Image(systemName: iconName)
+                .font(.subheadline)
+                .foregroundColor(.blue)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                HStack(alignment: .firstTextBaseline, spacing: 3) {
+                    Text(value)
+                        .font(.subheadline.weight(.bold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
+
+                    if !unit.isEmpty {
+                        Text(unit)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(height: 94)
+        .background(cardBackground)
+    }
+
+    private func editableMetricTile(title: String, value: String, unit: String, iconName: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            metricTile(title: title, value: value, unit: unit, iconName: iconName)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func dateEditorSheet(title: String, displayedComponents: DatePickerComponents, detent: PresentationDetent) -> some View {
+        NavigationStack {
+            VStack(spacing: 18) {
+                DatePicker(title, selection: $date, displayedComponents: displayedComponents)
+                    .datePickerStyle(.wheel)
+                    .labelsHidden()
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        TripManagerHapticsController.shared.lightTap()
+                        TripManagerSoundController.shared.playSound1()
+                        showDateEditor = false
+                        showTimeEditor = false
+                    }
+                }
+            }
+        }
+        .presentationDetents([detent])
+        .presentationDragIndicator(.visible)
+    }
+
+    private func revertAddressEdits() {
+        TripManagerHapticsController.shared.mediumTap()
+        TripManagerSoundController.shared.playSound1()
+
+        startAddress = trip.startAddress
+        endAddress = trip.endAddress
+        focusedField = nil
+        searchVM.results = []
+    }
+
+    private func openTripInAppleMaps() {
+        let encodedStart = startAddress.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let encodedEnd = endAddress.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+
+        guard let url = URL(string: "http://maps.apple.com/?saddr=\(encodedStart)&daddr=\(encodedEnd)&dirflg=d") else {
+            return
+        }
+
+        UIApplication.shared.open(url)
+    }
+
+    private func saveTrip() {
+        guard canSave else { return }
+
+        TripManagerHapticsController.shared.successConfirmationTap()
+        TripManagerSoundController.shared.playSound1()
+
+        isSaving = true
+        Task {
+            let distance = await TripsController.shared.calculateMiles(
+                from: startAddress,
+                to: endAddress
+            )
+
+            await MainActor.run {
+                trip.startAddress = startAddress
+                trip.endAddress = endAddress
+                trip.miles = distance
+                trip.date = date
+                try? context.save()
+                isSaving = false
+                focusedField = nil
+            }
         }
     }
 }


### PR DESCRIPTION
This PR refreshes the trip manager experience with a more polished trip details screen and clearer mileage analytics. Trip details now use a modern scrollable layout with a larger route preview, equal-sized summary cards for distance, date, and time, editable date/time popups, improved save/revert behavior, and Apple Maps launching from the route preview. Address editing now swaps the delete action for a revert action until changes are saved or discarded, and saving updates the trip in place without closing the sheet.

The trip details sheet has also been tuned to a fixed larger detent so both address fields fit more comfortably with bottom padding. The daily mileage chart was redesigned for readability with centered summary text, clearer labels, mileage values, and larger bars, and the weekly, monthly, and yearly mileage charts were resized and restyled to match that same card structure for a consistent trip manager analytics view.

Validation included Xcode live diagnostics on the edited Swift files and full project builds after the changes.