### PR TITLE
Adding Meeting Notes And Completion Summaries To Appointments - August '26 Release

### DIFF
--- a/d2d-activity-management-service/views/NoteRowCardCompact.swift
+++ b/d2d-activity-management-service/views/NoteRowCardCompact.swift
@@ -36,9 +36,9 @@ struct NoteRowCardCompact: View {
                 }
 
                 Text(attributed(content))
-                    .font(.subheadline) // smaller
+                    .font(.subheadline)
                     .foregroundStyle(.primary)
-                    .lineLimit(3)       // ⬅️ keep rows tidy
+                    .fixedSize(horizontal: false, vertical: true)
                     .textSelection(.enabled)
             }
             .padding(8)

--- a/d2d-customer-details-management-service/views/CustomerAppointmentsView.swift
+++ b/d2d-customer-details-management-service/views/CustomerAppointmentsView.swift
@@ -15,17 +15,16 @@ struct CustomerAppointmentsView: View {
     @State private var filter: AppointmentFilter = .upcoming
 
     private var filteredAppointments: [Appointment] {
-        let cal = Calendar.current
         let now = Date()
 
         switch filter {
         case .upcoming:
             return customer.appointments
-                .filter { $0.date >= cal.startOfDay(for: now) }
+                .filter { $0.isUpcomingBucket(now: now) }
                 .sorted { $0.date < $1.date }
         case .past:
             return customer.appointments
-                .filter { $0.date < cal.startOfDay(for: now) }
+                .filter { $0.isPastBucket(now: now) }
                 .sorted { $0.date > $1.date }
         default:
             return []

--- a/d2d-customer-details-management-service/views/ScheduleCustomerAppointmentView.swift
+++ b/d2d-customer-details-management-service/views/ScheduleCustomerAppointmentView.swift
@@ -26,7 +26,8 @@ struct ScheduleCustomerAppointmentView: View {
                 clientName: customer.fullName,
                 date: date,
                 type: type,
-                notes: customer.notes.map { $0.content }
+                notes: customer.notes.map { $0.content },
+                customer: customer
             )
 
             customer.appointments.append(appointment)

--- a/d2d-follow-up-service/controllers/AppointmentMeetingSummaryGenerator.swift
+++ b/d2d-follow-up-service/controllers/AppointmentMeetingSummaryGenerator.swift
@@ -31,8 +31,7 @@ struct AppointmentMeetingSummaryGenerator {
     }
 
     static func fallbackSummary(for input: AppointmentMeetingSummaryInput, completedAt: Date) -> String {
-        let formattedDate = input.appointmentDate.formatted(date: .abbreviated, time: .shortened)
-        let completedDate = completedAt.formatted(date: .abbreviated, time: .shortened)
+        let completedDate = completedAt.formatted(date: .long, time: .shortened)
         let trimmedNotes = input.meetingNotes
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { $0.isEmpty == false }
@@ -41,49 +40,234 @@ struct AppointmentMeetingSummaryGenerator {
             return "No notes were taken for \(input.clientName)'s meeting on \(completedDate)."
         }
 
-        let interpreted = interpretedFallback(from: trimmedNotes, clientName: input.clientName)
-        return "Meeting summary for \(input.clientName) from \(formattedDate): \(interpreted)"
+        return interpretedFallback(
+            from: trimmedNotes,
+            clientName: input.clientName,
+            completedAt: completedAt
+        )
     }
 
-    private static func interpretedFallback(from notes: [String], clientName: String) -> String {
+    private static func interpretedFallback(from notes: [String], clientName: String, completedAt: Date) -> String {
         let combined = notes.joined(separator: " ")
         let lower = combined.lowercased()
-        var insights: [String] = []
-        var nextStep = "Follow up after the next planned touchpoint."
+        let explicitTimeline = followUpTimeline(from: lower, completedAt: completedAt)
+        let moveAddress = movingAddress(from: combined)
+        let moveMonth = moveMonthText(from: lower, completedAt: completedAt)
+        let isRelocation = containsAny(lower, ["moving", "moves", "move", "college", "new address", "go to"])
+        let displayName = firstName(from: clientName)
+        var sentences = ["You met with \(displayName) on \(completedAt.formatted(date: .long, time: .shortened))."]
 
-        if containsAny(lower, ["no money", "can't afford", "cannot afford", "too expensive", "tight", "budget", "broke"]) {
-            insights.append("\(clientName) was not ready to buy because money is tight right now.")
-            nextStep = "Follow up in a month or two when the budget situation may be clearer."
+        if isRelocation {
+            sentences.append(relocationSentence(displayName: displayName, lower: lower, moveAddress: moveAddress, moveMonth: moveMonth))
+            sentences.append(relocationFollowUpSentence(moveAddress: moveAddress, moveMonth: moveMonth, explicitTimeline: explicitTimeline))
+            return sentences.joined(separator: " ")
         }
 
-        if containsAny(lower, ["wife", "husband", "ex", "divorce", "relationship", "family"]) {
-            insights.append("There are personal or relationship issues affecting the buying decision.")
+        if containsAny(lower, ["17", "minor", "too young", "underage"]) {
+            sentences.append("\(displayName) was not able to buy because he is not the decision maker.")
+        } else if containsAny(lower, ["no money", "can't afford", "cannot afford", "too expensive", "tight", "budget", "broke"]) {
+            sentences.append("\(displayName) was not ready to buy because money is tight right now.")
+        }
+
+        if lower.contains("mom") || lower.contains("mother") {
+            if containsAny(lower, ["cancer", "chemo", "chemotherapy", "treatment"]) {
+                sentences.append("His mom is the decision maker and is focused on cancer treatment, so she will not be ready to consider buying yet.")
+            } else {
+                sentences.append("His mom is the decision maker and needs to be involved before anything can move forward.")
+            }
+        } else if containsAny(lower, ["wife", "husband", "spouse", "partner"]) {
+            sentences.append("A household decision maker needs to be involved before anything can move forward.")
         }
 
         if containsAny(lower, ["interested", "wants", "liked", "needs", "good fit"]) {
-            insights.append("There was some buying interest or a potential fit discussed.")
+            sentences.append("There may still be a fit if the decision maker is ready later.")
         }
 
-        if containsAny(lower, ["not interested", "no interest", "declined", "said no"]) {
-            insights.append("The contact was not interested at this time.")
+        if containsAny(lower, ["not interested", "no interest", "declined", "said no"]), sentences.count == 1 {
+            sentences.append("\(displayName) was not interested at this time.")
         }
 
-        if containsAny(lower, ["call", "text", "email"]) {
-            nextStep = "Follow up using the requested communication channel."
+        if containsAny(lower, ["moving", "moves", "move"]) {
+            if let moveAddress, let moveMonth {
+                sentences.append("\(displayName) is moving to \(moveAddress) around \(moveMonth).")
+            } else if let moveAddress {
+                sentences.append("\(displayName) is moving to \(moveAddress).")
+            } else if let moveMonth {
+                sentences.append("\(displayName) is moving around \(moveMonth).")
+            }
         }
 
-        if containsAny(lower, ["month", "two months", "next month", "later"]) {
-            nextStep = "Follow up on the timeline mentioned during the meeting."
+        if sentences.count == 1 {
+            sentences.append("Review the meeting notes before the next contact: \(cleanRawNote(combined))")
         }
 
-        if insights.isEmpty {
-            let cleaned = combined
-                .replacingOccurrences(of: "\n", with: " ")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            insights.append("Meeting notes were captured and should be reviewed before the next contact: \(cleaned)")
+        if let explicitTimeline {
+            sentences.append(explicitTimeline)
+        } else if moveMonth != nil {
+            sentences.append("Follow up then.")
+        } else {
+            sentences.append("Follow up after the next planned touchpoint.")
+        }
+        return sentences.joined(separator: " ")
+    }
+
+    private static func relocationSentence(displayName: String, lower: String, moveAddress: String?, moveMonth: String?) -> String {
+        if lower.contains("college") {
+            if let moveAddress, let moveMonth {
+                return "Not a fit right now because \(displayName) is leaving for college and will need internet at \(moveAddress) around \(moveMonth)."
+            }
+
+            return "Not a fit right now because \(displayName) is leaving for college."
         }
 
-        return (insights + [nextStep]).joined(separator: " ")
+        if let moveAddress, let moveMonth {
+            return "\(displayName) is moving to \(moveAddress) around \(moveMonth)."
+        }
+
+        if let moveAddress {
+            return "\(displayName) is moving to \(moveAddress)."
+        }
+
+        if let moveMonth {
+            return "\(displayName) is moving around \(moveMonth)."
+        }
+
+        return "Not a fit right now because \(displayName) is relocating."
+    }
+
+    private static func relocationFollowUpSentence(moveAddress: String?, moveMonth: String?, explicitTimeline: String?) -> String {
+        if let moveAddress, let moveMonth {
+            return "Follow up at \(moveAddress) at the start of \(moveMonth)."
+        }
+
+        if let moveAddress {
+            return "Follow up at \(moveAddress)."
+        }
+
+        if let explicitTimeline {
+            return explicitTimeline
+        }
+
+        return "Follow up after the move."
+    }
+
+    private static func followUpTimeline(from text: String, completedAt: Date) -> String? {
+        if let range = firstMatch(in: text, pattern: #"follow\s*up\s*in\s*(\d+)\s*[-–]\s*(\d+)\s*(month|months|week|weeks)"#),
+           let low = Int(range[1]),
+           let high = Int(range[2]) {
+            let unit = range[3].hasPrefix("week") ? Calendar.Component.weekOfYear : .month
+            let calendarWindow = calendarWindowText(from: completedAt, low: low, high: high, unit: unit)
+            return "Follow up in \(low)-\(high) \(range[3])\(calendarWindow)."
+        }
+
+        if let single = firstMatch(in: text, pattern: #"follow\s*up\s*in\s*(\d+)\s*(month|months|week|weeks)"#),
+           let amount = Int(single[1]) {
+            let unit = single[2].hasPrefix("week") ? Calendar.Component.weekOfYear : .month
+            return followUpSentence(amount: amount, unitText: single[2], completedAt: completedAt, unit: unit)
+        }
+
+        if text.contains("next month") {
+            return "Follow up next month\(calendarWindowText(from: completedAt, low: 1, high: 1, unit: .month))."
+        }
+
+        if let implied = firstMatch(in: text, pattern: #"\bin\s*(\d+)\s*(month|months|week|weeks)\b"#),
+           let amount = Int(implied[1]) {
+            let unit = implied[2].hasPrefix("week") ? Calendar.Component.weekOfYear : .month
+            return followUpSentence(amount: amount, unitText: implied[2], completedAt: completedAt, unit: unit)
+        }
+
+        return nil
+    }
+
+    private static func movingAddress(from text: String) -> String? {
+        let patterns = [
+            #"\bto\s+([0-9][A-Za-z0-9 .,#-]+?\s+[A-Z]{2}\s+\d{5})"#,
+            #"\bat\s+([0-9][A-Za-z0-9 .,#-]+?\s+[A-Z]{2}\s+\d{5})"#
+        ]
+
+        for pattern in patterns {
+            if let match = firstMatch(in: text, pattern: pattern), match.count > 1 {
+                return cleanAddress(match[1])
+            }
+        }
+
+        return nil
+    }
+
+    private static func moveMonthText(from text: String, completedAt: Date) -> String? {
+        if let implied = firstMatch(in: text, pattern: #"\bin\s*(\d+)\s*(month|months|week|weeks)\b"#),
+           let amount = Int(implied[1]) {
+            let unit = implied[2].hasPrefix("week") ? Calendar.Component.weekOfYear : .month
+            return targetMonthText(amount: amount, completedAt: completedAt, unit: unit)
+        }
+
+        return nil
+    }
+
+    private static func cleanAddress(_ address: String) -> String {
+        address
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: "  ", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func followUpSentence(amount: Int, unitText: String, completedAt: Date, unit: Calendar.Component) -> String {
+        guard let targetMonth = targetMonthText(amount: amount, completedAt: completedAt, unit: unit) else {
+            return "Follow up in \(amount) \(unitText)."
+        }
+
+        return "Follow up in \(targetMonth)."
+    }
+
+    private static func targetMonthText(amount: Int, completedAt: Date, unit: Calendar.Component) -> String? {
+        let calendar = Calendar.current
+        guard let targetDate = calendar.date(byAdding: unit, value: amount, to: completedAt) else { return nil }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter.string(from: targetDate)
+    }
+
+    private static func calendarWindowText(from date: Date, low: Int, high: Int, unit: Calendar.Component) -> String {
+        let calendar = Calendar.current
+        guard let startDate = calendar.date(byAdding: unit, value: low, to: date) else { return "" }
+        let endDate = calendar.date(byAdding: unit, value: high, to: date) ?? startDate
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+
+        let start = formatter.string(from: startDate)
+        let end = formatter.string(from: endDate)
+
+        if start == end {
+            return ", around \(start)"
+        }
+
+        return ", around \(start)-\(end)"
+    }
+
+    private static func firstMatch(in text: String, pattern: String) -> [String]? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range) else { return nil }
+
+        return (0..<match.numberOfRanges).compactMap { index in
+            guard let swiftRange = Range(match.range(at: index), in: text) else { return nil }
+            return String(text[swiftRange])
+        }
+    }
+
+    private static func monthYear(from text: String) -> String? {
+        firstMatch(in: text, pattern: #"[A-Z][a-z]+\s+\d{4}"#)?.first
+    }
+
+    private static func firstName(from fullName: String) -> String {
+        fullName.split(separator: " ").first.map(String.init) ?? fullName
+    }
+
+    private static func cleanRawNote(_ note: String) -> String {
+        note
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private static func containsAny(_ text: String, _ terms: [String]) -> Bool {
@@ -96,46 +280,98 @@ struct AppointmentMeetingSummaryGenerator {
         let model = SystemLanguageModel.default
         guard model.isAvailable else { return nil }
 
-        let notes = input.meetingNotes
+        let trimmedNotes = input.meetingNotes
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { $0.isEmpty == false }
+        let notes = trimmedNotes
             .enumerated()
             .map { index, note in "\(index + 1). \(note)" }
             .joined(separator: "\n")
+        let combinedNotes = trimmedNotes.joined(separator: " ")
+        let requiredTimeline = Self.followUpTimeline(
+            from: combinedNotes.lowercased(),
+            completedAt: completedAt
+        )
+        let moveAddress = Self.movingAddress(from: combinedNotes)
+        let moveMonth = Self.moveMonthText(from: combinedNotes.lowercased(), completedAt: completedAt)
+        let isRelocation = Self.containsAny(combinedNotes.lowercased(), ["moving", "moves", "move", "college", "new address", "go to"])
 
         guard notes.isEmpty == false else {
             return "No notes were taken for \(input.clientName)'s meeting on \(completedAt.formatted(date: .abbreviated, time: .shortened))."
         }
 
         let instructions = """
-        You turn rough door-to-door sales meeting notes into one professional CRM note. Write only the final note. Do not quote profanity, sexual details, insults, gossip, or irrelevant personal details. Convert messy language into useful sales context: the decision blocker, buying signal, objection, next step, and suggested follow-up timing. Preserve meaning, but generalize sensitive personal information. Do not invent facts.
+        You turn rough door-to-door sales meeting notes into one professional CRM note. Write only the final note. Use this structure: first sentence says who the rep met with and when; next sentence explains the real buying blocker or decision maker issue; final sentence gives the exact follow-up date or window. Do not add a "Meeting summary:" prefix. Do not quote profanity, sexual details, insults, gossip, manipulative sales comments, or irrelevant personal details. Convert messy language into useful sales context. Preserve every explicit follow-up interval or date. Never replace a concrete timeline with vague wording like "the timeline mentioned". Do not invent facts.
         """
 
         let prompt = """
-        Client: \(input.clientName)
+        Client full name: \(input.clientName)
+        Client first name: \(Self.firstName(from: input.clientName))
         Appointment type: \(input.appointmentType)
         Scheduled time: \(input.appointmentDate.formatted(date: .abbreviated, time: .shortened))
-        Completed time: \(completedAt.formatted(date: .abbreviated, time: .shortened))
+        Completed time: \(completedAt.formatted(date: .long, time: .shortened))
 
         Meeting notes:
         \(notes)
 
-        Create a polished CRM note in 2 to 4 sentences. Start with "Meeting summary:". Example style: if the raw notes say the buyer has no money because of relationship problems, write that the buyer was not able to buy because money is tight due to personal relationship issues, then suggest following up in a month or two.
+        Required follow-up timing, if any:
+        \(requiredTimeline ?? "None")
+
+        Move address, if any:
+        \(moveAddress ?? "None")
+
+        Move timing, if any:
+        \(moveMonth ?? "None")
+
+        Relocation or college situation:
+        \(isRelocation ? "Yes" : "No")
+
+        Create a polished CRM note in 2 to 3 sentences. Sentence 1 must start with "You met with" and include the completed time. If this is a relocation or college situation, do not write generic buying-interest language. Say it is not a fit right now because the client is moving or leaving for college. If move address and move timing are present, include that exact address and month. If required follow-up timing is not None, the final sentence must use that exact timing or a more specific calendar date from it. For notes about a minor, parent, cancer treatment, or chemo, summarize professionally as a decision maker and timing blocker. Example college style: "You met with David on August 7, 2026 at 7:11 PM. Not a fit right now because David is leaving for college and will need internet at 1244 Ames St Ames IA 50014 around September 2026. Follow up at 1244 Ames St Ames IA 50014 at the start of September 2026." Example moving style: "You met with Kate on August 7, 2026 at 7:05 PM. Kate is moving to 10320 Norfolk Dr Los Angeles CA 90066 around October 2026. Follow up then."
         """
 
         do {
             let session = LanguageModelSession(instructions: instructions)
             let response = try await session.respond(to: prompt)
-            return cleaned(response.content)
+            return cleaned(
+                response.content,
+                requiredTimeline: requiredTimeline,
+                moveAddress: moveAddress,
+                moveMonth: moveMonth
+            )
         } catch {
             return nil
         }
     }
     #endif
 
-    private func cleaned(_ summary: String) -> String? {
+    private func cleaned(
+        _ summary: String,
+        requiredTimeline: String?,
+        moveAddress: String?,
+        moveMonth: String?
+    ) -> String? {
         let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.isEmpty == false else { return nil }
+
+        let lower = trimmed.lowercased()
+        guard lower.contains("timeline mentioned") == false else { return nil }
+
+        if let requiredTimeline {
+            let requiredMonth = Self.monthYear(from: requiredTimeline)
+            if lower.contains(requiredTimeline.lowercased()) == false,
+               requiredMonth.map({ lower.contains($0.lowercased()) }) != true {
+                return nil
+            }
+        }
+
+        if let moveAddress, lower.contains(moveAddress.lowercased()) == false {
+            return nil
+        }
+
+        if let moveMonth, lower.contains(moveMonth.lowercased()) == false {
+            return nil
+        }
+
         return trimmed
     }
 }

--- a/d2d-follow-up-service/controllers/AppointmentMeetingSummaryGenerator.swift
+++ b/d2d-follow-up-service/controllers/AppointmentMeetingSummaryGenerator.swift
@@ -1,0 +1,141 @@
+//
+//  AppointmentMeetingSummaryGenerator.swift
+//  d2d-studio
+//
+//  Created by Codex on 8/7/26.
+//
+
+import Foundation
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+struct AppointmentMeetingSummaryInput: Sendable {
+    let clientName: String
+    let appointmentType: String
+    let appointmentDate: Date
+    let meetingNotes: [String]
+}
+
+struct AppointmentMeetingSummaryGenerator {
+    func summary(for input: AppointmentMeetingSummaryInput, completedAt: Date) async -> String {
+        let fallback = Self.fallbackSummary(for: input, completedAt: completedAt)
+
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            return await foundationModelSummary(for: input, completedAt: completedAt) ?? fallback
+        }
+        #endif
+
+        return fallback
+    }
+
+    static func fallbackSummary(for input: AppointmentMeetingSummaryInput, completedAt: Date) -> String {
+        let formattedDate = input.appointmentDate.formatted(date: .abbreviated, time: .shortened)
+        let completedDate = completedAt.formatted(date: .abbreviated, time: .shortened)
+        let trimmedNotes = input.meetingNotes
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.isEmpty == false }
+
+        guard trimmedNotes.isEmpty == false else {
+            return "No notes were taken for \(input.clientName)'s meeting on \(completedDate)."
+        }
+
+        let interpreted = interpretedFallback(from: trimmedNotes, clientName: input.clientName)
+        return "Meeting summary for \(input.clientName) from \(formattedDate): \(interpreted)"
+    }
+
+    private static func interpretedFallback(from notes: [String], clientName: String) -> String {
+        let combined = notes.joined(separator: " ")
+        let lower = combined.lowercased()
+        var insights: [String] = []
+        var nextStep = "Follow up after the next planned touchpoint."
+
+        if containsAny(lower, ["no money", "can't afford", "cannot afford", "too expensive", "tight", "budget", "broke"]) {
+            insights.append("\(clientName) was not ready to buy because money is tight right now.")
+            nextStep = "Follow up in a month or two when the budget situation may be clearer."
+        }
+
+        if containsAny(lower, ["wife", "husband", "ex", "divorce", "relationship", "family"]) {
+            insights.append("There are personal or relationship issues affecting the buying decision.")
+        }
+
+        if containsAny(lower, ["interested", "wants", "liked", "needs", "good fit"]) {
+            insights.append("There was some buying interest or a potential fit discussed.")
+        }
+
+        if containsAny(lower, ["not interested", "no interest", "declined", "said no"]) {
+            insights.append("The contact was not interested at this time.")
+        }
+
+        if containsAny(lower, ["call", "text", "email"]) {
+            nextStep = "Follow up using the requested communication channel."
+        }
+
+        if containsAny(lower, ["month", "two months", "next month", "later"]) {
+            nextStep = "Follow up on the timeline mentioned during the meeting."
+        }
+
+        if insights.isEmpty {
+            let cleaned = combined
+                .replacingOccurrences(of: "\n", with: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            insights.append("Meeting notes were captured and should be reviewed before the next contact: \(cleaned)")
+        }
+
+        return (insights + [nextStep]).joined(separator: " ")
+    }
+
+    private static func containsAny(_ text: String, _ terms: [String]) -> Bool {
+        terms.contains { text.contains($0) }
+    }
+
+    #if canImport(FoundationModels)
+    @available(iOS 26.0, *)
+    private func foundationModelSummary(for input: AppointmentMeetingSummaryInput, completedAt: Date) async -> String? {
+        let model = SystemLanguageModel.default
+        guard model.isAvailable else { return nil }
+
+        let notes = input.meetingNotes
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.isEmpty == false }
+            .enumerated()
+            .map { index, note in "\(index + 1). \(note)" }
+            .joined(separator: "\n")
+
+        guard notes.isEmpty == false else {
+            return "No notes were taken for \(input.clientName)'s meeting on \(completedAt.formatted(date: .abbreviated, time: .shortened))."
+        }
+
+        let instructions = """
+        You turn rough door-to-door sales meeting notes into one professional CRM note. Write only the final note. Do not quote profanity, sexual details, insults, gossip, or irrelevant personal details. Convert messy language into useful sales context: the decision blocker, buying signal, objection, next step, and suggested follow-up timing. Preserve meaning, but generalize sensitive personal information. Do not invent facts.
+        """
+
+        let prompt = """
+        Client: \(input.clientName)
+        Appointment type: \(input.appointmentType)
+        Scheduled time: \(input.appointmentDate.formatted(date: .abbreviated, time: .shortened))
+        Completed time: \(completedAt.formatted(date: .abbreviated, time: .shortened))
+
+        Meeting notes:
+        \(notes)
+
+        Create a polished CRM note in 2 to 4 sentences. Start with "Meeting summary:". Example style: if the raw notes say the buyer has no money because of relationship problems, write that the buyer was not able to buy because money is tight due to personal relationship issues, then suggest following up in a month or two.
+        """
+
+        do {
+            let session = LanguageModelSession(instructions: instructions)
+            let response = try await session.respond(to: prompt)
+            return cleaned(response.content)
+        } catch {
+            return nil
+        }
+    }
+    #endif
+
+    private func cleaned(_ summary: String) -> String? {
+        let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else { return nil }
+        return trimmed
+    }
+}

--- a/d2d-follow-up-service/controllers/AppointmentNotesController.swift
+++ b/d2d-follow-up-service/controllers/AppointmentNotesController.swift
@@ -1,0 +1,84 @@
+//
+//  AppointmentNotesController.swift
+//  d2d-studio
+//
+//  Created by Codex on 8/7/26.
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+struct AppointmentNotesController {
+    let modelContext: ModelContext
+
+    func addMeetingNote(_ content: String, to appointment: Appointment) {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false, appointment.isClosed == false else { return }
+
+        appointment.meetingNotes.append(trimmed)
+        try? modelContext.save()
+    }
+
+    func completeIfNeeded(_ appointment: Appointment, at completedAt: Date = Date()) {
+        if appointment.isCompleted == false {
+            appointment.isCompleted = true
+            appointment.completedAt = completedAt
+        }
+
+        addSummaryToContactNotesIfNeeded(for: appointment, completedAt: completedAt)
+        try? modelContext.save()
+    }
+
+    func closePastAppointmentIfNeeded(_ appointment: Appointment, now: Date = Date()) {
+        guard appointment.date < now else { return }
+        completeIfNeeded(appointment, at: appointment.completedAt ?? appointment.date)
+    }
+
+    private func addSummaryToContactNotesIfNeeded(for appointment: Appointment, completedAt: Date) {
+        guard appointment.summaryAddedAt == nil else { return }
+
+        let summary = Self.summary(for: appointment, completedAt: completedAt)
+        appointment.meetingSummary = summary
+        appointment.summaryAddedAt = Date()
+
+        let contactNote = Note(content: summary, date: completedAt, prospect: appointment.prospect)
+
+        if let prospect = appointment.prospect {
+            prospect.notes.append(contactNote)
+        } else if let customer = appointment.customer {
+            customer.notes.append(contactNote)
+        }
+    }
+
+    static func summary(for appointment: Appointment, completedAt: Date) -> String {
+        let formattedDate = appointment.date.formatted(date: .abbreviated, time: .shortened)
+        let completedDate = completedAt.formatted(date: .abbreviated, time: .shortened)
+        let trimmedNotes = appointment.meetingNotes
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.isEmpty == false }
+
+        guard trimmedNotes.isEmpty == false else {
+            return "Meeting completed for \(appointment.clientName) on \(completedDate). No meeting notes were recorded."
+        }
+
+        let condensed = trimmedNotes
+            .prefix(4)
+            .map { summarizeLine($0) }
+            .joined(separator: " ")
+
+        return "Meeting summary for \(appointment.clientName) from \(formattedDate): \(condensed)"
+    }
+
+    private static func summarizeLine(_ line: String) -> String {
+        let normalized = line
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "  ", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard normalized.count > 180 else { return normalized }
+
+        let endIndex = normalized.index(normalized.startIndex, offsetBy: 180)
+        return String(normalized[..<endIndex]).trimmingCharacters(in: .whitespacesAndNewlines) + "..."
+    }
+}

--- a/d2d-follow-up-service/controllers/AppointmentNotesController.swift
+++ b/d2d-follow-up-service/controllers/AppointmentNotesController.swift
@@ -35,6 +35,17 @@ struct AppointmentNotesController {
         completeIfNeeded(appointment, at: appointment.completedAt ?? appointment.date)
     }
 
+    func reopenIfAllowed(_ appointment: Appointment, now: Date = Date()) {
+        guard appointment.canReopen(now: now) else { return }
+
+        removeSummaryFromContactNotesIfNeeded(for: appointment)
+        appointment.isCompleted = false
+        appointment.completedAt = nil
+        appointment.meetingSummary = nil
+        appointment.summaryAddedAt = nil
+        try? modelContext.save()
+    }
+
     private func addSummaryToContactNotesIfNeeded(for appointment: Appointment, completedAt: Date) {
         guard appointment.summaryAddedAt == nil else { return }
 
@@ -49,6 +60,22 @@ struct AppointmentNotesController {
         } else if let customer = appointment.customer {
             customer.notes.append(contactNote)
         }
+    }
+
+    private func removeSummaryFromContactNotesIfNeeded(for appointment: Appointment) {
+        guard let summary = appointment.meetingSummary else { return }
+
+        if let prospect = appointment.prospect {
+            removeSummary(summary, from: &prospect.notes)
+        } else if let customer = appointment.customer {
+            removeSummary(summary, from: &customer.notes)
+        }
+    }
+
+    private func removeSummary(_ summary: String, from notes: inout [Note]) {
+        let matchingNotes = notes.filter { $0.content == summary }
+        notes.removeAll { $0.content == summary }
+        matchingNotes.forEach { modelContext.delete($0) }
     }
 
     static func summary(for appointment: Appointment, completedAt: Date) -> String {

--- a/d2d-follow-up-service/controllers/AppointmentNotesController.swift
+++ b/d2d-follow-up-service/controllers/AppointmentNotesController.swift
@@ -11,6 +11,7 @@ import SwiftData
 @MainActor
 struct AppointmentNotesController {
     let modelContext: ModelContext
+    private let summaryGenerator = AppointmentMeetingSummaryGenerator()
 
     func addMeetingNote(_ content: String, to appointment: Appointment) {
         let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -20,19 +21,19 @@ struct AppointmentNotesController {
         try? modelContext.save()
     }
 
-    func completeIfNeeded(_ appointment: Appointment, at completedAt: Date = Date()) {
+    func completeIfNeeded(_ appointment: Appointment, at completedAt: Date = Date()) async {
         if appointment.isCompleted == false {
             appointment.isCompleted = true
             appointment.completedAt = completedAt
         }
 
-        addSummaryToContactNotesIfNeeded(for: appointment, completedAt: completedAt)
+        await addSummaryToContactNotesIfNeeded(for: appointment, completedAt: completedAt)
         try? modelContext.save()
     }
 
-    func closePastAppointmentIfNeeded(_ appointment: Appointment, now: Date = Date()) {
+    func closePastAppointmentIfNeeded(_ appointment: Appointment, now: Date = Date()) async {
         guard appointment.date < now else { return }
-        completeIfNeeded(appointment, at: appointment.completedAt ?? appointment.date)
+        await completeIfNeeded(appointment, at: appointment.completedAt ?? appointment.date)
     }
 
     func reopenIfAllowed(_ appointment: Appointment, now: Date = Date()) {
@@ -46,10 +47,16 @@ struct AppointmentNotesController {
         try? modelContext.save()
     }
 
-    private func addSummaryToContactNotesIfNeeded(for appointment: Appointment, completedAt: Date) {
+    private func addSummaryToContactNotesIfNeeded(for appointment: Appointment, completedAt: Date) async {
         guard appointment.summaryAddedAt == nil else { return }
 
-        let summary = Self.summary(for: appointment, completedAt: completedAt)
+        let summaryInput = AppointmentMeetingSummaryInput(
+            clientName: appointment.clientName,
+            appointmentType: appointment.type,
+            appointmentDate: appointment.date,
+            meetingNotes: appointment.meetingNotes
+        )
+        let summary = await summaryGenerator.summary(for: summaryInput, completedAt: completedAt)
         appointment.meetingSummary = summary
         appointment.summaryAddedAt = Date()
 
@@ -76,36 +83,5 @@ struct AppointmentNotesController {
         let matchingNotes = notes.filter { $0.content == summary }
         notes.removeAll { $0.content == summary }
         matchingNotes.forEach { modelContext.delete($0) }
-    }
-
-    static func summary(for appointment: Appointment, completedAt: Date) -> String {
-        let formattedDate = appointment.date.formatted(date: .abbreviated, time: .shortened)
-        let completedDate = completedAt.formatted(date: .abbreviated, time: .shortened)
-        let trimmedNotes = appointment.meetingNotes
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { $0.isEmpty == false }
-
-        guard trimmedNotes.isEmpty == false else {
-            return "Meeting completed for \(appointment.clientName) on \(completedDate). No meeting notes were recorded."
-        }
-
-        let condensed = trimmedNotes
-            .prefix(4)
-            .map { summarizeLine($0) }
-            .joined(separator: " ")
-
-        return "Meeting summary for \(appointment.clientName) from \(formattedDate): \(condensed)"
-    }
-
-    private static func summarizeLine(_ line: String) -> String {
-        let normalized = line
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "  ", with: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard normalized.count > 180 else { return normalized }
-
-        let endIndex = normalized.index(normalized.startIndex, offsetBy: 180)
-        return String(normalized[..<endIndex]).trimmingCharacters(in: .whitespacesAndNewlines) + "..."
     }
 }

--- a/d2d-follow-up-service/controllers/CalendarHelper.swift
+++ b/d2d-follow-up-service/controllers/CalendarHelper.swift
@@ -21,7 +21,7 @@ final class CalendarHelper: ObservableObject {
         let startDate = appointment.date
         let endDate = appointment.date.addingTimeInterval(60 * 30)
         let location = appointment.location
-        let notes = appointment.notes.joined(separator: "\n")
+        let notes = calendarNotes(for: appointment)
 
         @Sendable func handleAccess(granted: Bool, error: Error?) {
             if let error = error {
@@ -74,7 +74,7 @@ final class CalendarHelper: ObservableObject {
 
         let title = appointment.title.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         let location = appointment.location.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-        let details = appointment.notes.joined(separator: "\n").addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let details = calendarNotes(for: appointment).addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
 
         let urlString = """
         https://calendar.google.com/calendar/render?action=TEMPLATE&text=\(title)&dates=\(startUTC)/\(endUTC)&details=\(details)&location=\(location)&sf=true&output=xml
@@ -83,6 +83,21 @@ final class CalendarHelper: ObservableObject {
         if let url = URL(string: urlString), UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url)
         }
+    }
+
+    private func calendarNotes(for appointment: Appointment) -> String {
+        let contextNotes = appointment.notes.joined(separator: "\n")
+        let meetingNotes = appointment.meetingNotes.joined(separator: "\n")
+
+        if contextNotes.isEmpty {
+            return meetingNotes
+        }
+
+        if meetingNotes.isEmpty {
+            return contextNotes
+        }
+
+        return "\(contextNotes)\n\nMeeting Notes:\n\(meetingNotes)"
     }
 
     private func iso8601String(for date: Date) -> String {

--- a/d2d-follow-up-service/models/Appointment.swift
+++ b/d2d-follow-up-service/models/Appointment.swift
@@ -70,4 +70,16 @@ extension Appointment {
     var isClosed: Bool {
         isCompleted || isPastDue
     }
+
+    func isUpcomingBucket(now: Date = Date()) -> Bool {
+        isCompleted == false && date >= now
+    }
+
+    func isPastBucket(now: Date = Date()) -> Bool {
+        isCompleted || date < now
+    }
+
+    func canReopen(now: Date = Date()) -> Bool {
+        isCompleted && date >= now
+    }
 }

--- a/d2d-follow-up-service/models/Appointment.swift
+++ b/d2d-follow-up-service/models/Appointment.swift
@@ -16,10 +16,18 @@ class Appointment: Identifiable {
     var date: Date
     var type: String
     var notes: [String] = []
+    var meetingNotes: [String] = []
+    var isCompleted: Bool = false
+    var completedAt: Date?
+    var meetingSummary: String?
+    var summaryAddedAt: Date?
     var createdAt: Date
 
     @Relationship(inverse: \Prospect.appointments)
     var prospect: Prospect?
+
+    @Relationship(inverse: \Customer.appointments)
+    var customer: Customer?
 
     init(
         title: String,
@@ -28,7 +36,13 @@ class Appointment: Identifiable {
         date: Date,
         type: String,
         notes: [String] = [],
-        prospect: Prospect? = nil
+        meetingNotes: [String] = [],
+        isCompleted: Bool = false,
+        completedAt: Date? = nil,
+        meetingSummary: String? = nil,
+        summaryAddedAt: Date? = nil,
+        prospect: Prospect? = nil,
+        customer: Customer? = nil
     ) {
         self.id = UUID()
         self.title = title
@@ -37,7 +51,23 @@ class Appointment: Identifiable {
         self.date = date
         self.type = type
         self.notes = notes
+        self.meetingNotes = meetingNotes
+        self.isCompleted = isCompleted
+        self.completedAt = completedAt
+        self.meetingSummary = meetingSummary
+        self.summaryAddedAt = summaryAddedAt
         self.createdAt = .now
         self.prospect = prospect
+        self.customer = customer
+    }
+}
+
+extension Appointment {
+    var isPastDue: Bool {
+        date < Date()
+    }
+
+    var isClosed: Bool {
+        isCompleted || isPastDue
     }
 }

--- a/d2d-follow-up-service/views/AppointmentDetailsView.swift
+++ b/d2d-follow-up-service/views/AppointmentDetailsView.swift
@@ -16,6 +16,7 @@ struct AppointmentDetailsView: View {
 
     @State private var showRescheduleSheet = false
     @State private var newDate: Date = Date()
+    @State private var isGeneratingSummary = false
 
     private var notesController: AppointmentNotesController {
         AppointmentNotesController(modelContext: context)
@@ -26,10 +27,14 @@ struct AppointmentDetailsView: View {
     }
 
     private var isCompletionButtonDisabled: Bool {
-        appointment.isClosed && canReopenAppointment == false
+        isGeneratingSummary || (appointment.isClosed && canReopenAppointment == false)
     }
 
     private var completionButtonTitle: String {
+        if isGeneratingSummary {
+            return "Summarizing Notes"
+        }
+
         if canReopenAppointment {
             return "Reopen Meeting"
         }
@@ -38,6 +43,10 @@ struct AppointmentDetailsView: View {
     }
 
     private var completionButtonIcon: String {
+        if isGeneratingSummary {
+            return "sparkles"
+        }
+
         if canReopenAppointment {
             return "arrow.uturn.backward"
         }
@@ -119,7 +128,9 @@ struct AppointmentDetailsView: View {
                 .presentationDragIndicator(.visible)
             }
             .onAppear {
-                notesController.closePastAppointmentIfNeeded(appointment)
+                Task {
+                    await notesController.closePastAppointmentIfNeeded(appointment)
+                }
             }
         }
     }
@@ -212,7 +223,11 @@ struct AppointmentDetailsView: View {
             if canReopenAppointment {
                 notesController.reopenIfAllowed(appointment)
             } else {
-                notesController.completeIfNeeded(appointment)
+                isGeneratingSummary = true
+                Task {
+                    await notesController.completeIfNeeded(appointment)
+                    isGeneratingSummary = false
+                }
             }
         } label: {
             Label(completionButtonTitle, systemImage: completionButtonIcon)

--- a/d2d-follow-up-service/views/AppointmentDetailsView.swift
+++ b/d2d-follow-up-service/views/AppointmentDetailsView.swift
@@ -21,6 +21,38 @@ struct AppointmentDetailsView: View {
         AppointmentNotesController(modelContext: context)
     }
 
+    private var canReopenAppointment: Bool {
+        appointment.canReopen()
+    }
+
+    private var isCompletionButtonDisabled: Bool {
+        appointment.isClosed && canReopenAppointment == false
+    }
+
+    private var completionButtonTitle: String {
+        if canReopenAppointment {
+            return "Reopen Meeting"
+        }
+
+        return appointment.isClosed ? "Meeting Done" : "Confirm Meeting Done"
+    }
+
+    private var completionButtonIcon: String {
+        if canReopenAppointment {
+            return "arrow.uturn.backward"
+        }
+
+        return appointment.isClosed ? "checkmark.circle.fill" : "checkmark"
+    }
+
+    private var completionButtonColor: Color {
+        if isCompletionButtonDisabled {
+            return Color(.systemGray5)
+        }
+
+        return canReopenAppointment ? .orange : .blue
+    }
+
     var body: some View {
         NavigationStack {
             GeometryReader { geo in
@@ -176,9 +208,14 @@ struct AppointmentDetailsView: View {
         Button {
             FollowUpScreenHapticsController.shared.successConfirmationTap()
             FollowUpScreenSoundController.shared.playSound1()
-            notesController.completeIfNeeded(appointment)
+
+            if canReopenAppointment {
+                notesController.reopenIfAllowed(appointment)
+            } else {
+                notesController.completeIfNeeded(appointment)
+            }
         } label: {
-            Label(appointment.isClosed ? "Meeting Done" : "Confirm Meeting Done", systemImage: appointment.isClosed ? "checkmark.circle.fill" : "checkmark")
+            Label(completionButtonTitle, systemImage: completionButtonIcon)
                 .font(.headline)
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
@@ -186,9 +223,9 @@ struct AppointmentDetailsView: View {
                 .frame(height: 50)
         }
         .buttonStyle(.plain)
-        .foregroundColor(appointment.isClosed ? .secondary : .white)
-        .background(appointment.isClosed ? Color(.systemGray5) : Color.blue, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-        .disabled(appointment.isClosed)
+        .foregroundColor(isCompletionButtonDisabled ? .secondary : .white)
+        .background(completionButtonColor, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .disabled(isCompletionButtonDisabled)
     }
 
     private func card<Content: View>(@ViewBuilder content: () -> Content) -> some View {

--- a/d2d-follow-up-service/views/AppointmentDetailsView.swift
+++ b/d2d-follow-up-service/views/AppointmentDetailsView.swift
@@ -1,47 +1,34 @@
 //
-//  CancelAppointmentView.swift
+//  AppointmentDetailsView.swift
 //  d2d-studio
 //
 //  Created by Emin Okic on 7/6/25.
 //
+
 import SwiftUI
 import SwiftData
-@preconcurrency import EventKit
-
-private struct AppointmentDetailsEventStore: @unchecked Sendable {
-    let store: EKEventStore
-}
 
 struct AppointmentDetailsView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var context
 
-    let appointment: Appointment
+    @Bindable var appointment: Appointment
 
-    // State for reschedule and cancel prompts
     @State private var showRescheduleSheet = false
     @State private var newDate: Date = Date()
-    @State private var showSuccessBanner = false
-    @State private var successMessage = ""
+
+    private var notesController: AppointmentNotesController {
+        AppointmentNotesController(modelContext: context)
+    }
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(spacing: 16) {
+            GeometryReader { geo in
+                let isCompact = geo.size.height < 680
 
-                    // MARK: Header Card
-                    card {
-                        VStack(spacing: 8) {
-                            Text("Follow-Up Appointment")
-                                .font(.headline)
-                            Text(appointment.date.formatted(date: .long, time: .shortened))
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
+                VStack(spacing: isCompact ? 10 : 14) {
+                    headerCard(isCompact: isCompact)
 
-                    // MARK: Actions Toolbar Card
                     AppointmentActionsToolbar(
                         appointment: appointment,
                         onDelete: {
@@ -52,42 +39,24 @@ struct AppointmentDetailsView: View {
                             showRescheduleSheet = true
                         }
                     )
-                    .padding(.horizontal)
+                    .padding(.horizontal, 4)
 
-                    // MARK: Who & Where Card
-                    card {
-                        VStack(alignment: .leading, spacing: 6) {
-                            labeledField("Client") {
-                                Text(appointment.clientName)
-                                    .font(.subheadline)
-                            }
-                            labeledField("Location") {
-                                Text(appointment.location)
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                            }
-                        }
+                    contactCard(isCompact: isCompact)
+
+                    if appointment.notes.isEmpty == false && isCompact == false {
+                        contextNotesCard
                     }
 
-                    // MARK: Notes Card
-                    if !appointment.notes.isEmpty {
-                        card {
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text("Notes")
-                                    .font(.headline)
-                                ForEach(appointment.notes, id: \.self) { note in
-                                    Text("• \(note)")
-                                        .font(.body)
-                                        .fixedSize(horizontal: false, vertical: true)
-                                }
-                            }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                    }
+                    Spacer(minLength: 0)
 
-                    Spacer()
+                    notesCard
+
+                    completionButton
                 }
-                .padding()
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+                .padding(.bottom, 16)
+                .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
             }
             .background(Color(.systemGroupedBackground))
             .navigationTitle("Appointment Details")
@@ -109,54 +78,125 @@ struct AppointmentDetailsView: View {
                     original: appointment,
                     newDate: $newDate
                 ) {
-                    context.delete(appointment)
-                    let recreated = Appointment(
-                        title: appointment.title,
-                        location: appointment.location,
-                        clientName: appointment.clientName,
-                        date: newDate,
-                        type: appointment.type,
-                        notes: appointment.notes,
-                        prospect: appointment.prospect!
-                    )
-                    context.insert(recreated)
+                    appointment.date = newDate
                     try? context.save()
                     showRescheduleSheet = false
                     dismiss()
                 }
-                .presentationDetents([
-                    .fraction(0.35),
-                ])
+                .presentationDetents([.fraction(0.35)])
                 .presentationDragIndicator(.visible)
             }
-
-            // ✅ Success Banner floating over everything
-            if showSuccessBanner {
-                VStack {
-                    Spacer().frame(height: 60)
-                    Text(successMessage)
-                        .font(.subheadline)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .background(Color.green.opacity(0.95))
-                        .foregroundColor(.white)
-                        .cornerRadius(12)
-                        .shadow(radius: 6)
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                    Spacer()
-                }
-                .frame(maxWidth: .infinity)
-                .zIndex(999)
+            .onAppear {
+                notesController.closePastAppointmentIfNeeded(appointment)
             }
         }
     }
-    
+
+    private func headerCard(isCompact: Bool) -> some View {
+        card {
+            HStack(alignment: .center, spacing: 12) {
+                Image(systemName: appointment.isClosed ? "checkmark.seal.fill" : "calendar")
+                    .font(.system(size: isCompact ? 16 : 18, weight: .semibold))
+                    .foregroundColor(appointment.isClosed ? .secondary : .blue)
+                    .frame(width: 36, height: 36)
+                    .background((appointment.isClosed ? Color.gray : Color.blue).opacity(0.12), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(appointment.type)
+                        .font(.headline.weight(.semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+
+                    Text(appointment.date.formatted(date: .long, time: .shortened))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                }
+
+                Spacer(minLength: 0)
+
+                Text(appointment.isClosed ? "Done" : "Open")
+                    .font(.caption.weight(.bold))
+                    .foregroundColor(appointment.isClosed ? .secondary : .blue)
+                    .padding(.horizontal, 9)
+                    .padding(.vertical, 6)
+                    .background((appointment.isClosed ? Color.gray : Color.blue).opacity(0.10), in: Capsule())
+            }
+        }
+    }
+
+    private func contactCard(isCompact: Bool) -> some View {
+        card {
+            VStack(alignment: .leading, spacing: isCompact ? 8 : 10) {
+                labeledField("Client") {
+                    Text(appointment.clientName)
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.82)
+                }
+
+                labeledField("Location") {
+                    Text(appointment.location)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .lineLimit(2)
+                }
+            }
+        }
+    }
+
+    private var contextNotesCard: some View {
+        card {
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Contact Context", systemImage: "text.bubble")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                ForEach(appointment.notes.prefix(2), id: \.self) { note in
+                    Text(note)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    private var notesCard: some View {
+        card {
+            AppointmentMeetingNotesView(appointment: appointment) { note in
+                notesController.addMeetingNote(note, to: appointment)
+            }
+        }
+    }
+
+    private var completionButton: some View {
+        Button {
+            FollowUpScreenHapticsController.shared.successConfirmationTap()
+            FollowUpScreenSoundController.shared.playSound1()
+            notesController.completeIfNeeded(appointment)
+        } label: {
+            Label(appointment.isClosed ? "Meeting Done" : "Confirm Meeting Done", systemImage: appointment.isClosed ? "checkmark.circle.fill" : "checkmark")
+                .font(.headline)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+                .frame(maxWidth: .infinity)
+                .frame(height: 50)
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(appointment.isClosed ? .secondary : .white)
+        .background(appointment.isClosed ? Color(.systemGray5) : Color.blue, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .disabled(appointment.isClosed)
+    }
+
     private func card<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         content()
-            .padding()
+            .padding(14)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
-                RoundedRectangle(cornerRadius: 16)
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .fill(Color(.systemBackground))
                     .shadow(color: .black.opacity(0.05), radius: 6, x: 0, y: 3)
             )
@@ -170,92 +210,4 @@ struct AppointmentDetailsView: View {
             content()
         }
     }
-    
-    // Helper function for opening in maps
-    private func openInAppleMaps(destination: String) {
-        let encodedAddress = destination.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-        let urlString = "http://maps.apple.com/?daddr=\(encodedAddress)&dirflg=d"
-
-        if let url = URL(string: urlString), UIApplication.shared.canOpenURL(url) {
-            UIApplication.shared.open(url)
-        }
-    }
-    
-    private func addAppointmentToCalendar(_ appointment: Appointment) {
-        let eventStore = AppointmentDetailsEventStore(store: EKEventStore())
-        let title = appointment.title
-        let startDate = appointment.date
-        let endDate = appointment.date.addingTimeInterval(60 * 30)
-        let location = appointment.location
-        let notes = appointment.notes.joined(separator: "\n")
-
-        let showCalendarFeedback: @Sendable (String) -> Void = { message in
-            Task { @MainActor in
-                showFeedback(message)
-            }
-        }
-
-        let handleAccess: @Sendable (Bool, Error?) -> Void = { granted, error in
-            if let error = error {
-                showCalendarFeedback("Calendar access error: \(error.localizedDescription)")
-                return
-            }
-
-            if granted {
-                let predicate = eventStore.store.predicateForEvents(
-                    withStart: startDate.addingTimeInterval(-60),
-                    end: startDate.addingTimeInterval(60),
-                    calendars: nil
-                )
-
-                let existing = eventStore.store.events(matching: predicate).first {
-                    $0.title == title && $0.location == location
-                }
-
-                if existing != nil {
-                    showCalendarFeedback("Already exists in calendar.")
-                    return
-                }
-
-                let event = EKEvent(eventStore: eventStore.store)
-                event.title = title
-                event.startDate = startDate
-                event.endDate = endDate
-                event.notes = notes
-                event.location = location
-                event.calendar = eventStore.store.defaultCalendarForNewEvents
-
-                do {
-                    try eventStore.store.save(event, span: .thisEvent)
-                    showCalendarFeedback("Successfully added to calendar!")
-                } catch {
-                    showCalendarFeedback("Failed to save event: \(error.localizedDescription)")
-                }
-            } else {
-                showCalendarFeedback("Calendar access denied. Enable in Settings.")
-            }
-        }
-
-        if #available(iOS 17.0, *) {
-            eventStore.store.requestFullAccessToEvents(completion: handleAccess)
-        } else {
-            eventStore.store.requestAccess(to: .event, completion: handleAccess)
-        }
-    }
-
-    private func showFeedback(_ message: String) {
-        DispatchQueue.main.async {
-            successMessage = message
-            withAnimation {
-                showSuccessBanner = true
-            }
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
-                withAnimation {
-                    showSuccessBanner = false
-                }
-            }
-        }
-    }
-    
 }

--- a/d2d-follow-up-service/views/AppointmentMeetingNotesView.swift
+++ b/d2d-follow-up-service/views/AppointmentMeetingNotesView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct AppointmentMeetingNotesView: View {
     let appointment: Appointment
@@ -76,8 +77,14 @@ struct AppointmentMeetingNotesView: View {
                         Text(note)
                             .font(.caption)
                             .foregroundStyle(.primary)
-                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
+                            .contextMenu {
+                                Button("Copy") {
+                                    UIPasteboard.general.string = note
+                                }
+                            }
                     }
                 }
             }

--- a/d2d-follow-up-service/views/AppointmentMeetingNotesView.swift
+++ b/d2d-follow-up-service/views/AppointmentMeetingNotesView.swift
@@ -1,0 +1,87 @@
+//
+//  AppointmentMeetingNotesView.swift
+//  d2d-studio
+//
+//  Created by Codex on 8/7/26.
+//
+
+import SwiftUI
+
+struct AppointmentMeetingNotesView: View {
+    let appointment: Appointment
+    let onAddNote: (String) -> Void
+
+    @State private var draftNote = ""
+
+    private var canAddNote: Bool {
+        draftNote.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false && appointment.isClosed == false
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Label("Meeting Notes", systemImage: "note.text")
+                    .font(.headline)
+                Spacer(minLength: 0)
+                if appointment.isClosed {
+                    Label("Done", systemImage: "checkmark.circle.fill")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            notesList
+
+            HStack(alignment: .bottom, spacing: 8) {
+                TextField("Add meeting note", text: $draftNote, axis: .vertical)
+                    .font(.subheadline)
+                    .lineLimit(2...4)
+                    .padding(10)
+                    .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    .disabled(appointment.isClosed)
+
+                Button {
+                    onAddNote(draftNote)
+                    draftNote = ""
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 14, weight: .bold))
+                        .frame(width: 38, height: 38)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(canAddNote ? .white : .secondary)
+                .background(canAddNote ? Color.blue : Color(.systemGray5), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .disabled(canAddNote == false)
+                .accessibilityLabel("Add Meeting Note")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var notesList: some View {
+        if appointment.meetingNotes.isEmpty {
+            Text(appointment.isClosed ? "No meeting notes were captured." : "Capture sales notes before closing this meeting.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+        } else {
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(Array(appointment.meetingNotes.enumerated()), id: \.offset) { _, note in
+                    HStack(alignment: .top, spacing: 6) {
+                        Circle()
+                            .fill(Color.blue.opacity(0.55))
+                            .frame(width: 5, height: 5)
+                            .padding(.top, 7)
+
+                        Text(note)
+                            .font(.caption)
+                            .foregroundStyle(.primary)
+                            .lineLimit(2)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .topLeading)
+        }
+    }
+}

--- a/d2d-follow-up-service/views/AppointmentsSectionView.swift
+++ b/d2d-follow-up-service/views/AppointmentsSectionView.swift
@@ -28,8 +28,8 @@ struct AppointmentsSectionView: View {
 
     private var now: Date { Date() }
 
-    private var upcomingCount: Int { appointments.filter { $0.date >= now }.count }
-    private var pastCount: Int { appointments.filter { $0.date <  now }.count }
+    private var upcomingCount: Int { appointments.filter { $0.isUpcomingBucket(now: now) }.count }
+    private var pastCount: Int { appointments.filter { $0.isPastBucket(now: now) }.count }
     
     @Binding var filteredAppointments: [Appointment]
 
@@ -40,15 +40,15 @@ struct AppointmentsSectionView: View {
         switch filter {
         case .today:
             return appointments
-                .filter { calendar.isDate($0.date, inSameDayAs: now) }
+                .filter { calendar.isDate($0.date, inSameDayAs: now) && $0.isUpcomingBucket(now: now) }
                 .sorted { $0.date < $1.date }
         case .upcoming:
             return appointments
-                .filter { $0.date >= now && !calendar.isDateInToday($0.date) }
+                .filter { $0.isUpcomingBucket(now: now) && !calendar.isDateInToday($0.date) }
                 .sorted { $0.date < $1.date }
         case .past:
             return appointments
-                .filter { $0.date < now && !calendar.isDateInToday($0.date) }
+                .filter { $0.isPastBucket(now: now) }
                 .sorted { $0.date > $1.date }
         }
     }
@@ -69,10 +69,10 @@ struct AppointmentsSectionView: View {
                         let calendar = Calendar.current
                         let now = Date()
                         Text(filter == .today
-                             ? "\(appointments.filter { calendar.isDate($0.date, inSameDayAs: now) }.count) Today's Appointments"
+                             ? "\(appointments.filter { calendar.isDate($0.date, inSameDayAs: now) && $0.isUpcomingBucket(now: now) }.count) Today's Appointments"
                              : filter == .upcoming
-                             ? "\(appointments.filter { $0.date >= now && !calendar.isDateInToday($0.date) }.count) Upcoming Appointments"
-                             : "\(appointments.filter { $0.date < now && !calendar.isDateInToday($0.date) }.count) Past Appointments")
+                             ? "\(appointments.filter { $0.isUpcomingBucket(now: now) && !calendar.isDateInToday($0.date) }.count) Upcoming Appointments"
+                             : "\(appointments.filter { $0.isPastBucket(now: now) }.count) Past Appointments")
                             .font(.subheadline)
                             .foregroundColor(.secondary)
                     }

--- a/d2d-prospect-details-management-service/views/ProspectAppointmentsView.swift
+++ b/d2d-prospect-details-management-service/views/ProspectAppointmentsView.swift
@@ -15,17 +15,16 @@ struct ProspectAppointmentsView: View {
     @State private var filter: AppointmentFilter = .upcoming
 
     private var filteredAppointments: [Appointment] {
-        let cal = Calendar.current
         let now = Date()
 
         switch filter {
         case .upcoming:
             return prospect.appointments
-                .filter { $0.date >= cal.startOfDay(for: now) }
+                .filter { $0.isUpcomingBucket(now: now) }
                 .sorted { $0.date < $1.date }
         case .past:
             return prospect.appointments
-                .filter { $0.date < cal.startOfDay(for: now) }
+                .filter { $0.isPastBucket(now: now) }
                 .sorted { $0.date > $1.date }
         default:
             return []

--- a/d2d-studio.xcodeproj/project.pbxproj
+++ b/d2d-studio.xcodeproj/project.pbxproj
@@ -707,7 +707,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;
@@ -757,7 +757,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;

--- a/d2d-territory-management-service/MapSearchView.swift
+++ b/d2d-territory-management-service/MapSearchView.swift
@@ -1176,7 +1176,8 @@ struct MapSearchView: View {
                 clientName: customer.fullName,
                 date: date,
                 type: "Follow-Up",
-                notes: customer.notes.map { $0.content }
+                notes: customer.notes.map { $0.content },
+                customer: customer
             )
 
             customer.appointments.append(appt)


### PR DESCRIPTION
Adding a dedicated meeting notes system to appointment details so sales reps can capture notes during follow-ups and automatically roll those notes into the main contact notes once the meeting is complete.

Changes:
- Added meeting notes, completion status, completion date, and summary tracking to appointments
- Added a modular appointment notes controller to handle note saving, meeting completion, and summary creation
- Added a notes section at the bottom of appointment details with no outer scroll
- Added a “Confirm Meeting Done” action that summarizes meeting notes into the prospect/customer notes
- Automatically closes past appointments and greys out the completion action once done
- Preserved customer ownership on customer appointments so summaries save back to the right contact
- Updated calendar export to include meeting notes when available

Testing:
- Built the project successfully in Xcode
- Verified changed files have no Xcode diagnostics