### PR TITLE
Creating A Duplicate Catching System For The Business Card Scanning Feature - August '26 Bug Fix

### DIFF
--- a/d2d-contact-import-service/ImportOverlayView.swift
+++ b/d2d-contact-import-service/ImportOverlayView.swift
@@ -225,13 +225,18 @@ struct ImportOverlayView: View {
 
         let draftName = normalizedText(draft.fullName)
         let contactName = normalizedText(contact.fullName)
+        guard isUsableName(draftName), draftName == contactName else {
+            return false
+        }
+
         let draftAddress = normalizedText(draft.address)
         let contactAddress = normalizedText(contact.address)
 
-        return !draftName.isEmpty &&
-            draftName == contactName &&
-            !draftAddress.isEmpty &&
-            draftAddress == contactAddress
+        if isUsableAddress(draftAddress), draftAddress == contactAddress {
+            return true
+        }
+
+        return !isUsableAddress(draftAddress)
     }
 
     private func updateExistingContact(
@@ -264,7 +269,7 @@ struct ImportOverlayView: View {
         if fields.contains(.phone), !draft.phone.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             contact.contactPhone = draft.phone
         }
-        if fields.contains(.address), !draft.address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if fields.contains(.address), isUsableAddress(normalizedText(draft.address)) {
             contact.address = draft.address
         }
     }
@@ -292,6 +297,14 @@ struct ImportOverlayView: View {
 
     private func normalizedText(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private func isUsableName(_ value: String) -> Bool {
+        !value.isEmpty && value != "unknown" && value.split(separator: " ").count >= 2
+    }
+
+    private func isUsableAddress(_ value: String) -> Bool {
+        !value.isEmpty && value != "no address"
     }
 
     private func digitsOnly(_ value: String) -> String {

--- a/d2d-contact-import-service/ImportOverlayView.swift
+++ b/d2d-contact-import-service/ImportOverlayView.swift
@@ -250,31 +250,73 @@ struct ImportOverlayView: View {
         switch duplicate.type {
         case .prospect:
             guard let prospect = duplicate.prospect else { return }
-            apply(draft, to: prospect, fields: fields)
+            let changeNotes = apply(draft, to: prospect, fields: fields)
+            appendBusinessCardMergeNotes(changeNotes, to: prospect)
         case .customer:
             guard let customer = duplicate.customer else { return }
-            apply(draft, to: customer, fields: fields)
+            let changeNotes = apply(draft, to: customer, fields: fields)
+            appendBusinessCardMergeNotes(changeNotes, to: customer)
         }
 
         try? modelContext.save()
         onSave()
     }
 
-    private func apply(_ draft: ProspectDraft, to contact: any ContactProtocol, fields: Set<BusinessCardMergeField>) {
+    private func apply(_ draft: ProspectDraft, to contact: any ContactProtocol, fields: Set<BusinessCardMergeField>) -> [String] {
         var contact = contact
+        var changeNotes: [String] = []
 
         if fields.contains(.name), !draft.fullName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            contact.fullName = draft.fullName
+            let oldValue = contact.fullName
+            if oldValue != draft.fullName {
+                contact.fullName = draft.fullName
+                changeNotes.append(changeNote(fieldName: "Name", oldValue: oldValue, newValue: draft.fullName))
+            }
         }
         if fields.contains(.email), !draft.email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            contact.contactEmail = draft.email
+            let oldValue = contact.contactEmail
+            if oldValue != draft.email {
+                contact.contactEmail = draft.email
+                changeNotes.append(changeNote(fieldName: "Email", oldValue: oldValue, newValue: draft.email))
+            }
         }
         if fields.contains(.phone), !draft.phone.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            contact.contactPhone = draft.phone
+            let oldValue = contact.contactPhone
+            if oldValue != draft.phone {
+                contact.contactPhone = draft.phone
+                changeNotes.append(changeNote(fieldName: "Phone", oldValue: oldValue, newValue: draft.phone))
+            }
         }
         if fields.contains(.address), isUsableAddress(normalizedText(draft.address)) {
-            contact.address = draft.address
+            let oldValue = contact.address
+            if oldValue != draft.address {
+                contact.address = draft.address
+                changeNotes.append(changeNote(fieldName: "Address", oldValue: oldValue, newValue: draft.address))
+            }
         }
+
+        return changeNotes
+    }
+
+    private func appendBusinessCardMergeNotes(_ changeNotes: [String], to prospect: Prospect) {
+        for content in changeNotes {
+            prospect.notes.append(Note(content: content, date: Date(), prospect: prospect))
+        }
+    }
+
+    private func appendBusinessCardMergeNotes(_ changeNotes: [String], to customer: Customer) {
+        for content in changeNotes {
+            customer.notes.append(Note(content: content, date: Date()))
+        }
+    }
+
+    private func changeNote(fieldName: String, oldValue: String, newValue: String) -> String {
+        "Business card scan updated \(fieldName.lowercased()) from \(displayValueForNote(oldValue)) to \(displayValueForNote(newValue))."
+    }
+
+    private func displayValueForNote(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Not set" : trimmed
     }
 
     private func openExistingContact(_ duplicate: BusinessCardDuplicateCandidate) {

--- a/d2d-contact-import-service/ImportOverlayView.swift
+++ b/d2d-contact-import-service/ImportOverlayView.swift
@@ -22,6 +22,8 @@ struct ImportOverlayView: View {
     let customers: [Customer]
     let modelContext: ModelContext
     let onSave: () -> Void
+    let onOpenDuplicateProspect: (Prospect) -> Void
+    let onOpenDuplicateCustomer: (Customer) -> Void
     
     let onAddManually: () -> Void
 
@@ -29,6 +31,7 @@ struct ImportOverlayView: View {
     
     @State private var showBusinessCardScanner = false
     @State private var scannedProspectDraft: ProspectDraft?
+    @State private var businessCardDuplicate: BusinessCardDuplicateCandidate?
     
     @StateObject private var importManager: ContactImportManager
     
@@ -45,6 +48,8 @@ struct ImportOverlayView: View {
         customers: [Customer],
         modelContext: ModelContext,
         onSave: @escaping () -> Void,
+        onOpenDuplicateProspect: @escaping (Prospect) -> Void,
+        onOpenDuplicateCustomer: @escaping (Customer) -> Void,
         onAddManually: @escaping () -> Void,
         showDuplicateToast: Binding<Bool>,
         duplicateNames: Binding<[String]>
@@ -57,6 +62,8 @@ struct ImportOverlayView: View {
         self.customers = customers
         self.modelContext = modelContext
         self.onSave = onSave
+        self.onOpenDuplicateProspect = onOpenDuplicateProspect
+        self.onOpenDuplicateCustomer = onOpenDuplicateCustomer
         self.onAddManually = onAddManually
 
         // ✅ Initialize StateObject here
@@ -154,9 +161,23 @@ struct ImportOverlayView: View {
                 .sheet(item: $scannedProspectDraft) { draft in
                     BusinessCardConfirmView(
                         draft: draft,
+                        duplicate: businessCardDuplicate,
                         onConfirm: { confirmedDraft in
                             saveProspect(confirmedDraft)
                             scannedProspectDraft = nil
+                            businessCardDuplicate = nil
+                            showingImportFromContacts = false
+                        },
+                        onUpdateExisting: { duplicate, fields in
+                            updateExistingContact(duplicate, with: draft, fields: fields)
+                            scannedProspectDraft = nil
+                            businessCardDuplicate = nil
+                            showingImportFromContacts = false
+                        },
+                        onOpenExisting: { duplicate in
+                            openExistingContact(duplicate)
+                            scannedProspectDraft = nil
+                            businessCardDuplicate = nil
                             showingImportFromContacts = false
                         }
                     )
@@ -164,6 +185,7 @@ struct ImportOverlayView: View {
                 .sheet(isPresented: $showBusinessCardScanner) {
                     BusinessCardScannerView(
                         onScanned: { draft in
+                            businessCardDuplicate = findDuplicate(for: draft)
                             scannedProspectDraft = draft
                             showBusinessCardScanner = false
                         },
@@ -176,6 +198,106 @@ struct ImportOverlayView: View {
         }
     }
     
+    private func findDuplicate(for draft: ProspectDraft) -> BusinessCardDuplicateCandidate? {
+        if let prospect = prospects.first(where: { isDuplicate(draft, of: $0) }) {
+            return BusinessCardDuplicateCandidate(prospect: prospect)
+        }
+
+        if let customer = customers.first(where: { isDuplicate(draft, of: $0) }) {
+            return BusinessCardDuplicateCandidate(customer: customer)
+        }
+
+        return nil
+    }
+
+    private func isDuplicate(_ draft: ProspectDraft, of contact: any ContactProtocol) -> Bool {
+        let draftEmail = normalizedEmail(draft.email)
+        let contactEmail = normalizedEmail(contact.contactEmail)
+        if !draftEmail.isEmpty && draftEmail == contactEmail {
+            return true
+        }
+
+        let draftPhone = digitsOnly(draft.phone)
+        let contactPhone = digitsOnly(contact.contactPhone)
+        if draftPhone.count >= 7 && draftPhone == contactPhone {
+            return true
+        }
+
+        let draftName = normalizedText(draft.fullName)
+        let contactName = normalizedText(contact.fullName)
+        let draftAddress = normalizedText(draft.address)
+        let contactAddress = normalizedText(contact.address)
+
+        return !draftName.isEmpty &&
+            draftName == contactName &&
+            !draftAddress.isEmpty &&
+            draftAddress == contactAddress
+    }
+
+    private func updateExistingContact(
+        _ duplicate: BusinessCardDuplicateCandidate,
+        with draft: ProspectDraft,
+        fields: Set<BusinessCardMergeField>
+    ) {
+        switch duplicate.type {
+        case .prospect:
+            guard let prospect = duplicate.prospect else { return }
+            apply(draft, to: prospect, fields: fields)
+        case .customer:
+            guard let customer = duplicate.customer else { return }
+            apply(draft, to: customer, fields: fields)
+        }
+
+        try? modelContext.save()
+        onSave()
+    }
+
+    private func apply(_ draft: ProspectDraft, to contact: any ContactProtocol, fields: Set<BusinessCardMergeField>) {
+        var contact = contact
+
+        if fields.contains(.name), !draft.fullName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            contact.fullName = draft.fullName
+        }
+        if fields.contains(.email), !draft.email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            contact.contactEmail = draft.email
+        }
+        if fields.contains(.phone), !draft.phone.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            contact.contactPhone = draft.phone
+        }
+        if fields.contains(.address), !draft.address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            contact.address = draft.address
+        }
+    }
+
+    private func openExistingContact(_ duplicate: BusinessCardDuplicateCandidate) {
+        switch duplicate.type {
+        case .prospect:
+            guard let prospect = duplicate.prospect else { return }
+            selectedList = "Prospects"
+            DispatchQueue.main.async {
+                onOpenDuplicateProspect(prospect)
+            }
+        case .customer:
+            guard let customer = duplicate.customer else { return }
+            selectedList = "Customers"
+            DispatchQueue.main.async {
+                onOpenDuplicateCustomer(customer)
+            }
+        }
+    }
+
+    private func normalizedEmail(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private func normalizedText(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private func digitsOnly(_ value: String) -> String {
+        value.filter(\.isNumber)
+    }
+
     private func saveProspect(_ draft: ProspectDraft) {
         let prospect = Prospect(
             fullName: draft.fullName,

--- a/d2d-contact-import-service/ImportOverlayView.swift
+++ b/d2d-contact-import-service/ImportOverlayView.swift
@@ -30,8 +30,7 @@ struct ImportOverlayView: View {
     @State private var showContactsPicker = false
     
     @State private var showBusinessCardScanner = false
-    @State private var scannedProspectDraft: ProspectDraft?
-    @State private var businessCardDuplicate: BusinessCardDuplicateCandidate?
+    @State private var businessCardReview: BusinessCardReview?
     
     @StateObject private var importManager: ContactImportManager
     
@@ -158,26 +157,23 @@ struct ImportOverlayView: View {
                         onCancel: { showContactsPicker = false }
                     )
                 }
-                .sheet(item: $scannedProspectDraft) { draft in
+                .sheet(item: $businessCardReview) { review in
                     BusinessCardConfirmView(
-                        draft: draft,
-                        duplicate: businessCardDuplicate,
+                        draft: review.draft,
+                        duplicate: review.duplicate,
                         onConfirm: { confirmedDraft in
                             saveProspect(confirmedDraft)
-                            scannedProspectDraft = nil
-                            businessCardDuplicate = nil
+                            businessCardReview = nil
                             showingImportFromContacts = false
                         },
                         onUpdateExisting: { duplicate, fields in
-                            updateExistingContact(duplicate, with: draft, fields: fields)
-                            scannedProspectDraft = nil
-                            businessCardDuplicate = nil
+                            updateExistingContact(duplicate, with: review.draft, fields: fields)
+                            businessCardReview = nil
                             showingImportFromContacts = false
                         },
                         onOpenExisting: { duplicate in
                             openExistingContact(duplicate)
-                            scannedProspectDraft = nil
-                            businessCardDuplicate = nil
+                            businessCardReview = nil
                             showingImportFromContacts = false
                         }
                     )
@@ -185,9 +181,14 @@ struct ImportOverlayView: View {
                 .sheet(isPresented: $showBusinessCardScanner) {
                     BusinessCardScannerView(
                         onScanned: { draft in
-                            businessCardDuplicate = findDuplicate(for: draft)
-                            scannedProspectDraft = draft
                             showBusinessCardScanner = false
+                            let review = BusinessCardReview(
+                                draft: draft,
+                                duplicate: findDuplicate(for: draft)
+                            )
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                                businessCardReview = review
+                            }
                         },
                         onCancel: {
                             showBusinessCardScanner = false
@@ -199,11 +200,14 @@ struct ImportOverlayView: View {
     }
     
     private func findDuplicate(for draft: ProspectDraft) -> BusinessCardDuplicateCandidate? {
-        if let prospect = prospects.first(where: { isDuplicate(draft, of: $0) }) {
+        let currentProspects = (try? modelContext.fetch(FetchDescriptor<Prospect>())) ?? prospects
+        let currentCustomers = (try? modelContext.fetch(FetchDescriptor<Customer>())) ?? customers
+
+        if let prospect = currentProspects.first(where: { isDuplicate(draft, of: $0) }) {
             return BusinessCardDuplicateCandidate(prospect: prospect)
         }
 
-        if let customer = customers.first(where: { isDuplicate(draft, of: $0) }) {
+        if let customer = currentCustomers.first(where: { isDuplicate(draft, of: $0) }) {
             return BusinessCardDuplicateCandidate(customer: customer)
         }
 
@@ -211,32 +215,31 @@ struct ImportOverlayView: View {
     }
 
     private func isDuplicate(_ draft: ProspectDraft, of contact: any ContactProtocol) -> Bool {
+        let draftName = normalizedText(draft.fullName)
+        let contactName = normalizedText(contact.fullName)
+        if isUsableName(draftName), isUsableName(contactName), draftName == contactName {
+            return true
+        }
+
+        let draftAddress = normalizedText(draft.address)
+        let contactAddress = normalizedText(contact.address)
+        if isUsableAddress(draftAddress), isUsableAddress(contactAddress), draftAddress == contactAddress {
+            return true
+        }
+
         let draftEmail = normalizedEmail(draft.email)
         let contactEmail = normalizedEmail(contact.contactEmail)
-        if !draftEmail.isEmpty && draftEmail == contactEmail {
+        if !draftEmail.isEmpty, !contactEmail.isEmpty, draftEmail == contactEmail {
             return true
         }
 
         let draftPhone = digitsOnly(draft.phone)
         let contactPhone = digitsOnly(contact.contactPhone)
-        if draftPhone.count >= 7 && draftPhone == contactPhone {
+        if phoneNumbersMatch(draftPhone, contactPhone) {
             return true
         }
 
-        let draftName = normalizedText(draft.fullName)
-        let contactName = normalizedText(contact.fullName)
-        guard isUsableName(draftName), draftName == contactName else {
-            return false
-        }
-
-        let draftAddress = normalizedText(draft.address)
-        let contactAddress = normalizedText(contact.address)
-
-        if isUsableAddress(draftAddress), draftAddress == contactAddress {
-            return true
-        }
-
-        return !isUsableAddress(draftAddress)
+        return false
     }
 
     private func updateExistingContact(
@@ -296,7 +299,17 @@ struct ImportOverlayView: View {
     }
 
     private func normalizedText(_ value: String) -> String {
-        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let folded = value
+            .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+            .lowercased()
+
+        let scalars = folded.unicodeScalars.map { scalar in
+            CharacterSet.alphanumerics.contains(scalar) ? Character(scalar) : " "
+        }
+
+        return String(scalars)
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
     }
 
     private func isUsableName(_ value: String) -> Bool {
@@ -304,11 +317,18 @@ struct ImportOverlayView: View {
     }
 
     private func isUsableAddress(_ value: String) -> Bool {
-        !value.isEmpty && value != "no address"
+        !value.isEmpty && value != "no address" && value != "noaddress"
     }
 
     private func digitsOnly(_ value: String) -> String {
         value.filter(\.isNumber)
+    }
+
+    private func phoneNumbersMatch(_ lhs: String, _ rhs: String) -> Bool {
+        guard lhs.count >= 7, rhs.count >= 7 else { return false }
+        if lhs == rhs { return true }
+
+        return lhs.suffix(7) == rhs.suffix(7)
     }
 
     private func saveProspect(_ draft: ProspectDraft) {

--- a/d2d-contact-import-service/models/BusinessCardDuplicateCandidate.swift
+++ b/d2d-contact-import-service/models/BusinessCardDuplicateCandidate.swift
@@ -1,0 +1,107 @@
+//
+//  BusinessCardDuplicateCandidate.swift
+//  d2d-studio
+//
+
+import Foundation
+
+enum BusinessCardDuplicateContactType {
+    case prospect
+    case customer
+}
+
+struct BusinessCardDuplicateCandidate: Identifiable {
+    let id = UUID()
+    let type: BusinessCardDuplicateContactType
+    let prospect: Prospect?
+    let customer: Customer?
+
+    init(prospect: Prospect) {
+        self.type = .prospect
+        self.prospect = prospect
+        self.customer = nil
+    }
+
+    init(customer: Customer) {
+        self.type = .customer
+        self.prospect = nil
+        self.customer = customer
+    }
+
+    var title: String {
+        contact?.fullName ?? "Existing Contact"
+    }
+
+    var subtitle: String {
+        switch type {
+        case .prospect:
+            return "Prospect"
+        case .customer:
+            return "Customer"
+        }
+    }
+
+    var contact: (any ContactProtocol)? {
+        prospect ?? customer
+    }
+
+    var address: String {
+        contact?.address ?? ""
+    }
+
+    var phone: String {
+        contact?.contactPhone ?? ""
+    }
+
+    var email: String {
+        contact?.contactEmail ?? ""
+    }
+}
+
+enum BusinessCardMergeField: String, CaseIterable, Identifiable {
+    case name
+    case email
+    case phone
+    case address
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .name:
+            return "Name"
+        case .email:
+            return "Email"
+        case .phone:
+            return "Phone"
+        case .address:
+            return "Address"
+        }
+    }
+
+    func value(from draft: ProspectDraft) -> String {
+        switch self {
+        case .name:
+            return draft.fullName
+        case .email:
+            return draft.email
+        case .phone:
+            return draft.phone
+        case .address:
+            return draft.address
+        }
+    }
+
+    func existingValue(from duplicate: BusinessCardDuplicateCandidate) -> String {
+        switch self {
+        case .name:
+            return duplicate.title
+        case .email:
+            return duplicate.email
+        case .phone:
+            return duplicate.phone
+        case .address:
+            return duplicate.address
+        }
+    }
+}

--- a/d2d-contact-import-service/models/BusinessCardDuplicateCandidate.swift
+++ b/d2d-contact-import-service/models/BusinessCardDuplicateCandidate.swift
@@ -10,6 +10,12 @@ enum BusinessCardDuplicateContactType {
     case customer
 }
 
+struct BusinessCardReview: Identifiable {
+    let id = UUID()
+    let draft: ProspectDraft
+    let duplicate: BusinessCardDuplicateCandidate?
+}
+
 struct BusinessCardDuplicateCandidate: Identifiable {
     let id = UUID()
     let type: BusinessCardDuplicateContactType
@@ -100,7 +106,8 @@ enum BusinessCardMergeField: String, CaseIterable, Identifiable {
         case .name:
             return value.lowercased() != "unknown" && value.split(separator: " ").count >= 2
         case .address:
-            return value.lowercased() != "no address"
+            let normalizedValue = value.lowercased().replacingOccurrences(of: " ", with: "")
+            return normalizedValue != "noaddress"
         case .email, .phone:
             return true
         }

--- a/d2d-contact-import-service/models/BusinessCardDuplicateCandidate.swift
+++ b/d2d-contact-import-service/models/BusinessCardDuplicateCandidate.swift
@@ -92,6 +92,20 @@ enum BusinessCardMergeField: String, CaseIterable, Identifiable {
         }
     }
 
+    func isUsableValue(from draft: ProspectDraft) -> Bool {
+        let value = value(from: draft).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return false }
+
+        switch self {
+        case .name:
+            return value.lowercased() != "unknown" && value.split(separator: " ").count >= 2
+        case .address:
+            return value.lowercased() != "no address"
+        case .email, .phone:
+            return true
+        }
+    }
+
     func existingValue(from duplicate: BusinessCardDuplicateCandidate) -> String {
         switch self {
         case .name:

--- a/d2d-contact-import-service/models/BusinessCardDuplicateCandidate.swift
+++ b/d2d-contact-import-service/models/BusinessCardDuplicateCandidate.swift
@@ -125,4 +125,38 @@ enum BusinessCardMergeField: String, CaseIterable, Identifiable {
             return duplicate.address
         }
     }
+
+    func hasSameValue(draft: ProspectDraft, duplicate: BusinessCardDuplicateCandidate) -> Bool {
+        let newValue = value(from: draft)
+        let existingValue = existingValue(from: duplicate)
+
+        switch self {
+        case .name, .address:
+            return normalizedText(newValue) == normalizedText(existingValue)
+        case .email:
+            return newValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ==
+                existingValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        case .phone:
+            let newDigits = newValue.filter(\.isNumber)
+            let existingDigits = existingValue.filter(\.isNumber)
+            guard !newDigits.isEmpty, !existingDigits.isEmpty else {
+                return newDigits == existingDigits
+            }
+            return newDigits == existingDigits || newDigits.suffix(7) == existingDigits.suffix(7)
+        }
+    }
+
+    private func normalizedText(_ value: String) -> String {
+        let folded = value
+            .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+            .lowercased()
+
+        let scalars = folded.unicodeScalars.map { scalar in
+            CharacterSet.alphanumerics.contains(scalar) ? Character(scalar) : " "
+        }
+
+        return String(scalars)
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+    }
 }

--- a/d2d-contact-import-service/views/BusinessCardConfirmView.swift
+++ b/d2d-contact-import-service/views/BusinessCardConfirmView.swift
@@ -9,41 +9,247 @@ import SwiftUI
 
 struct BusinessCardConfirmView: View {
     let draft: ProspectDraft
+    let duplicate: BusinessCardDuplicateCandidate?
     let onConfirm: (ProspectDraft) -> Void
+    let onUpdateExisting: (BusinessCardDuplicateCandidate, Set<BusinessCardMergeField>) -> Void
+    let onOpenExisting: (BusinessCardDuplicateCandidate) -> Void
+
     @Environment(\.dismiss) private var dismiss
+    @State private var isPickingMergeFields = false
+    @State private var selectedMergeFields: Set<BusinessCardMergeField> = []
+
+    init(
+        draft: ProspectDraft,
+        duplicate: BusinessCardDuplicateCandidate? = nil,
+        onConfirm: @escaping (ProspectDraft) -> Void,
+        onUpdateExisting: @escaping (BusinessCardDuplicateCandidate, Set<BusinessCardMergeField>) -> Void = { _, _ in },
+        onOpenExisting: @escaping (BusinessCardDuplicateCandidate) -> Void = { _ in }
+    ) {
+        self.draft = draft
+        self.duplicate = duplicate
+        self.onConfirm = onConfirm
+        self.onUpdateExisting = onUpdateExisting
+        self.onOpenExisting = onOpenExisting
+    }
 
     var body: some View {
-        VStack(spacing: 20) {
-            Text("Confirm Prospect")
-                .font(.title2)
-                .bold()
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Name: \(draft.fullName)")
-                Text("Email: \(draft.email)")
-                Text("Phone: \(draft.phone)")
-                Text("Address: \(draft.address)")
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    if let duplicate {
+                        duplicateContent(duplicate)
+                    } else {
+                        uniqueContent
+                    }
+                }
+                .padding(20)
             }
-            .padding()
-            .background(.ultraThinMaterial)
-            .cornerRadius(12)
+            .navigationTitle(duplicate == nil ? "Confirm Prospect" : "Possible Duplicate")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+            .onAppear {
+                selectedMergeFields = defaultMergeFields()
+            }
+        }
+    }
 
-            HStack {
-                Button("Cancel") {
-                    dismiss()
+    private var uniqueContent: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            scannedCardSection
+
+            Button {
+                onConfirm(draft)
+                dismiss()
+            } label: {
+                Label("Add Prospect", systemImage: "person.crop.circle.badge.plus")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+
+    private func duplicateContent(_ duplicate: BusinessCardDuplicateCandidate) -> some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Label("This card looks like an existing \(duplicate.subtitle.lowercased()).", systemImage: "exclamationmark.triangle.fill")
+                .font(.headline)
+                .foregroundStyle(.orange)
+
+            duplicateSummary(duplicate)
+            scannedCardSection
+
+            if isPickingMergeFields {
+                mergeFieldPicker(for: duplicate)
+            } else {
+                duplicateActions(duplicate)
+            }
+        }
+    }
+
+    private var scannedCardSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Scanned Card")
+                .font(.headline)
+
+            contactRow(title: "Name", value: draft.fullName, systemImage: "person")
+            contactRow(title: "Email", value: draft.email, systemImage: "envelope")
+            contactRow(title: "Phone", value: draft.phone, systemImage: "phone")
+            contactRow(title: "Address", value: draft.address, systemImage: "mappin.and.ellipse")
+        }
+        .padding()
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func duplicateSummary(_ duplicate: BusinessCardDuplicateCandidate) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: duplicate.type == .prospect ? "person.text.rectangle" : "person.crop.square.filled.and.at.rectangle")
+                    .font(.title2)
+                    .foregroundStyle(.blue)
+                    .frame(width: 30)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(duplicate.title)
+                        .font(.headline)
+                    Text(duplicate.subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+            }
+
+            contactRow(title: "Email", value: duplicate.email, systemImage: "envelope")
+            contactRow(title: "Phone", value: duplicate.phone, systemImage: "phone")
+            contactRow(title: "Address", value: duplicate.address, systemImage: "mappin.and.ellipse")
+        }
+        .padding()
+        .background(.thinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func duplicateActions(_ duplicate: BusinessCardDuplicateCandidate) -> some View {
+        VStack(spacing: 12) {
+            Button {
+                isPickingMergeFields = true
+            } label: {
+                Label("Edit Existing Contact", systemImage: "square.and.pencil")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Button {
+                onOpenExisting(duplicate)
+                dismiss()
+            } label: {
+                Label("Open Existing Contact", systemImage: "arrow.up.forward.app")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+
+            Button {
+                onConfirm(draft)
+                dismiss()
+            } label: {
+                Label("Add as New Prospect", systemImage: "plus.circle")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    private func mergeFieldPicker(for duplicate: BusinessCardDuplicateCandidate) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Choose fields to replace")
+                .font(.headline)
+
+            ForEach(BusinessCardMergeField.allCases) { field in
+                let newValue = field.value(from: draft)
+                if !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Button {
+                        toggle(field)
+                    } label: {
+                        HStack(alignment: .top, spacing: 12) {
+                            Image(systemName: selectedMergeFields.contains(field) ? "checkmark.circle.fill" : "circle")
+                                .foregroundStyle(selectedMergeFields.contains(field) ? .blue : .secondary)
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(field.title)
+                                    .font(.subheadline.weight(.semibold))
+                                Text("Current: \(displayValue(field.existingValue(from: duplicate)))")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text("Card: \(newValue)")
+                                    .font(.caption)
+                            }
+
+                            Spacer()
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            HStack(spacing: 12) {
+                Button("Back") {
+                    isPickingMergeFields = false
                 }
                 .buttonStyle(.bordered)
 
-                Spacer()
-
-                Button("Confirm") {
-                    onConfirm(draft)
+                Button("Apply Updates") {
+                    onUpdateExisting(duplicate, selectedMergeFields)
                     dismiss()
                 }
                 .buttonStyle(.borderedProminent)
+                .disabled(selectedMergeFields.isEmpty)
             }
         }
         .padding()
-        .frame(width: 300)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func contactRow(title: String, value: String, systemImage: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: systemImage)
+                .foregroundStyle(.secondary)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(displayValue(value))
+                    .font(.subheadline)
+                    .textSelection(.enabled)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func defaultMergeFields() -> Set<BusinessCardMergeField> {
+        Set(BusinessCardMergeField.allCases.filter { field in
+            let value = field.value(from: draft).trimmingCharacters(in: .whitespacesAndNewlines)
+            return !value.isEmpty && value != "Unknown" && value != "No Address"
+        })
+    }
+
+    private func toggle(_ field: BusinessCardMergeField) {
+        if selectedMergeFields.contains(field) {
+            selectedMergeFields.remove(field)
+        } else {
+            selectedMergeFields.insert(field)
+        }
+    }
+
+    private func displayValue(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Not set" : trimmed
     }
 }

--- a/d2d-contact-import-service/views/BusinessCardConfirmView.swift
+++ b/d2d-contact-import-service/views/BusinessCardConfirmView.swift
@@ -15,7 +15,7 @@ struct BusinessCardConfirmView: View {
     let onOpenExisting: (BusinessCardDuplicateCandidate) -> Void
 
     @Environment(\.dismiss) private var dismiss
-    @State private var isPickingMergeFields = false
+    @State private var duplicateStep: DuplicateStep = .review
     @State private var selectedMergeFields: Set<BusinessCardMergeField> = []
 
     init(
@@ -37,25 +37,53 @@ struct BusinessCardConfirmView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
                     if let duplicate {
-                        duplicateContent(duplicate)
+                        switch duplicateStep {
+                        case .review:
+                            duplicateReviewContent(duplicate)
+                        case .replaceFields:
+                            replaceFieldsContent(duplicate)
+                        }
                     } else {
                         uniqueContent
                     }
                 }
                 .padding(20)
+                .padding(.bottom, duplicate == nil ? 0 : 20)
             }
-            .navigationTitle(duplicate == nil ? "Confirm Prospect" : "Possible Duplicate")
+            .navigationTitle(navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") {
-                        dismiss()
+                    if duplicateStep == .replaceFields {
+                        Button("Back") {
+                            duplicateStep = .review
+                        }
+                    } else {
+                        Button("Cancel") {
+                            dismiss()
+                        }
                     }
                 }
             }
             .onAppear {
-                selectedMergeFields = defaultMergeFields()
+                selectedMergeFields = Set(replaceableFields(for: duplicate))
             }
+            .onChange(of: duplicateStep) { _, newValue in
+                if newValue == .replaceFields {
+                    selectedMergeFields = Set(replaceableFields(for: duplicate))
+                }
+            }
+        }
+    }
+
+    private var navigationTitle: String {
+        guard duplicate != nil else { return "Confirm Prospect" }
+
+        switch duplicateStep {
+        case .review:
+            return "Possible Duplicate"
+        case .replaceFields:
+            return "Replace Fields"
         }
     }
 
@@ -74,19 +102,69 @@ struct BusinessCardConfirmView: View {
         }
     }
 
-    private func duplicateContent(_ duplicate: BusinessCardDuplicateCandidate) -> some View {
+    private func duplicateReviewContent(_ duplicate: BusinessCardDuplicateCandidate) -> some View {
         VStack(alignment: .leading, spacing: 18) {
-            Label("This card looks like an existing \(duplicate.subtitle.lowercased()).", systemImage: "exclamationmark.triangle.fill")
-                .font(.headline)
-                .foregroundStyle(.orange)
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Possible duplicate found", systemImage: "exclamationmark.triangle.fill")
+                    .font(.headline)
+                    .foregroundStyle(.orange)
+
+                Text("This scanned card matches an existing \(duplicate.subtitle.lowercased()). Choose whether to update the existing contact or add a separate prospect.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
 
             duplicateSummary(duplicate)
             scannedCardSection
+            duplicateActions(duplicate)
+        }
+    }
 
-            if isPickingMergeFields {
-                mergeFieldPicker(for: duplicate)
+    private func replaceFieldsContent(_ duplicate: BusinessCardDuplicateCandidate) -> some View {
+        let fields = replaceableFields(for: duplicate)
+
+        return VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Select Fields to Replace")
+                    .font(.title3.weight(.semibold))
+
+                Text("Only fields with new values different from the existing contact are shown.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            duplicateSummary(duplicate)
+
+            if fields.isEmpty {
+                ContentUnavailableView(
+                    "No New Fields",
+                    systemImage: "checkmark.seal",
+                    description: Text("The scanned card does not have any usable values that differ from this contact.")
+                )
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 24)
             } else {
-                duplicateActions(duplicate)
+                VStack(spacing: 10) {
+                    ForEach(fields) { field in
+                        mergeFieldRow(field, duplicate: duplicate)
+                    }
+                }
+            }
+
+            HStack(spacing: 12) {
+                Button("Cancel") {
+                    dismiss()
+                }
+                .buttonStyle(.bordered)
+                .frame(maxWidth: .infinity)
+
+                Button("Apply Updates") {
+                    onUpdateExisting(duplicate, selectedMergeFields)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .frame(maxWidth: .infinity)
+                .disabled(selectedMergeFields.isEmpty)
             }
         }
     }
@@ -137,83 +215,119 @@ struct BusinessCardConfirmView: View {
     private func duplicateActions(_ duplicate: BusinessCardDuplicateCandidate) -> some View {
         VStack(spacing: 12) {
             Button {
-                isPickingMergeFields = true
+                duplicateStep = .replaceFields
             } label: {
-                Label("Edit Existing Contact", systemImage: "square.and.pencil")
-                    .frame(maxWidth: .infinity)
+                actionButtonContent(
+                    title: "Edit Existing",
+                    subtitle: "Review which scanned fields replace saved values",
+                    systemImage: "arrow.triangle.2.circlepath"
+                )
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(.plain)
+            .disabled(replaceableFields(for: duplicate).isEmpty)
+            .opacity(replaceableFields(for: duplicate).isEmpty ? 0.55 : 1)
 
-            Button {
-                onOpenExisting(duplicate)
-                dismiss()
-            } label: {
-                Label("Open Existing Contact", systemImage: "arrow.up.forward.app")
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.bordered)
+            HStack(spacing: 12) {
+                Button {
+                    onOpenExisting(duplicate)
+                    dismiss()
+                } label: {
+                    compactActionContent(title: "Open", systemImage: "arrow.up.forward.app")
+                }
+                .buttonStyle(.plain)
 
-            Button {
-                onConfirm(draft)
-                dismiss()
-            } label: {
-                Label("Add as New Prospect", systemImage: "plus.circle")
-                    .frame(maxWidth: .infinity)
+                Button {
+                    onConfirm(draft)
+                    dismiss()
+                } label: {
+                    compactActionContent(title: "Add New", systemImage: "plus.circle")
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.bordered)
         }
     }
 
-    private func mergeFieldPicker(for duplicate: BusinessCardDuplicateCandidate) -> some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text("Choose fields to replace")
-                .font(.headline)
+    private func actionButtonContent(title: String, subtitle: String, systemImage: String) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: systemImage)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.white)
+                .frame(width: 38, height: 38)
+                .background(Circle().fill(Color.accentColor))
 
-            ForEach(BusinessCardMergeField.allCases) { field in
-                let newValue = field.value(from: draft)
-                if field.isUsableValue(from: draft) {
-                    Button {
-                        toggle(field)
-                    } label: {
-                        HStack(alignment: .top, spacing: 12) {
-                            Image(systemName: selectedMergeFields.contains(field) ? "checkmark.circle.fill" : "circle")
-                                .foregroundStyle(selectedMergeFields.contains(field) ? .blue : .secondary)
-
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(field.title)
-                                    .font(.subheadline.weight(.semibold))
-                                Text("Current: \(displayValue(field.existingValue(from: duplicate)))")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                Text("Card: \(newValue)")
-                                    .font(.caption)
-                            }
-
-                            Spacer()
-                        }
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                }
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
             }
 
-            HStack(spacing: 12) {
-                Button("Back") {
-                    isPickingMergeFields = false
-                }
-                .buttonStyle(.bordered)
+            Spacer()
 
-                Button("Apply Updates") {
-                    onUpdateExisting(duplicate, selectedMergeFields)
-                    dismiss()
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(selectedMergeFields.isEmpty)
-            }
+            Image(systemName: "chevron.right")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
         }
-        .padding()
+        .padding(14)
         .background(.ultraThinMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .strokeBorder(Color.primary.opacity(0.08))
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    private func compactActionContent(title: String, systemImage: String) -> some View {
+        Label(title, systemImage: systemImage)
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.primary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 13)
+            .background(.thinMaterial)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(Color.primary.opacity(0.08))
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func mergeFieldRow(_ field: BusinessCardMergeField, duplicate: BusinessCardDuplicateCandidate) -> some View {
+        let isSelected = selectedMergeFields.contains(field)
+        let newValue = field.value(from: draft)
+
+        return Button {
+            toggle(field)
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundStyle(isSelected ? .blue : .secondary)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(field.title)
+                        .font(.subheadline.weight(.semibold))
+                    Text("Current: \(displayValue(field.existingValue(from: duplicate)))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("New: \(newValue)")
+                        .font(.caption)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(14)
+            .background(.ultraThinMaterial)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(isSelected ? Color.blue.opacity(0.5) : Color.primary.opacity(0.08))
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
     }
 
     private func contactRow(title: String, value: String, systemImage: String) -> some View {
@@ -233,10 +347,12 @@ struct BusinessCardConfirmView: View {
         }
     }
 
-    private func defaultMergeFields() -> Set<BusinessCardMergeField> {
-        Set(BusinessCardMergeField.allCases.filter { field in
-            field.isUsableValue(from: draft)
-        })
+    private func replaceableFields(for duplicate: BusinessCardDuplicateCandidate?) -> [BusinessCardMergeField] {
+        guard let duplicate else { return [] }
+
+        return BusinessCardMergeField.allCases.filter { field in
+            field.isUsableValue(from: draft) && !field.hasSameValue(draft: draft, duplicate: duplicate)
+        }
     }
 
     private func toggle(_ field: BusinessCardMergeField) {
@@ -251,4 +367,9 @@ struct BusinessCardConfirmView: View {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "Not set" : trimmed
     }
+}
+
+private enum DuplicateStep {
+    case review
+    case replaceFields
 }

--- a/d2d-contact-import-service/views/BusinessCardConfirmView.swift
+++ b/d2d-contact-import-service/views/BusinessCardConfirmView.swift
@@ -171,7 +171,7 @@ struct BusinessCardConfirmView: View {
 
             ForEach(BusinessCardMergeField.allCases) { field in
                 let newValue = field.value(from: draft)
-                if !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                if field.isUsableValue(from: draft) {
                     Button {
                         toggle(field)
                     } label: {
@@ -235,8 +235,7 @@ struct BusinessCardConfirmView: View {
 
     private func defaultMergeFields() -> Set<BusinessCardMergeField> {
         Set(BusinessCardMergeField.allCases.filter { field in
-            let value = field.value(from: draft).trimmingCharacters(in: .whitespacesAndNewlines)
-            return !value.isEmpty && value != "Unknown" && value != "No Address"
+            field.isUsableValue(from: draft)
         })
     }
 

--- a/d2d-contact-management-service/ContactManagementView.swift
+++ b/d2d-contact-management-service/ContactManagementView.swift
@@ -130,6 +130,12 @@ struct ContactManagementView: View {
                     customers: customers,
                     modelContext: modelContext,
                     onSave: onSave,
+                    onOpenDuplicateProspect: { prospect in
+                        selectedProspect = prospect
+                    },
+                    onOpenDuplicateCustomer: { customer in
+                        selectedCustomer = customer
+                    },
                     onAddManually: {
                         showingAddProspect = true
                     },

--- a/d2d-studio.xcodeproj/project.pbxproj
+++ b/d2d-studio.xcodeproj/project.pbxproj
@@ -699,7 +699,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;
@@ -749,7 +749,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;

--- a/d2d-studio.xcodeproj/project.pbxproj
+++ b/d2d-studio.xcodeproj/project.pbxproj
@@ -699,7 +699,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;
@@ -749,7 +749,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;

--- a/d2d-studio.xcodeproj/project.pbxproj
+++ b/d2d-studio.xcodeproj/project.pbxproj
@@ -699,7 +699,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;
@@ -749,7 +749,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;

--- a/d2d-studio.xcodeproj/project.pbxproj
+++ b/d2d-studio.xcodeproj/project.pbxproj
@@ -699,7 +699,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;
@@ -749,7 +749,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;

--- a/d2d-studio.xcodeproj/project.pbxproj
+++ b/d2d-studio.xcodeproj/project.pbxproj
@@ -699,7 +699,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;
@@ -749,7 +749,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;

--- a/d2d-studio.xcodeproj/project.pbxproj
+++ b/d2d-studio.xcodeproj/project.pbxproj
@@ -699,7 +699,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;
@@ -749,7 +749,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Y3JJD7DBP3;
 				ENABLE_PREVIEWS = YES;


### PR DESCRIPTION
Adds duplicate handling to the business card scanner before scanned contacts are inserted into the CRM. The scanner now checks existing prospects and customers by email, phone, exact name/address, and exact name when the scanned card has no usable address. When a possible duplicate is found, the user sees an interstitial warning instead of an automatic insert, with options to add the scanned card anyway, open the existing contact, or edit the existing contact. The edit flow includes a field mapping screen where the user chooses which usable scanned fields should replace existing values, and placeholder values like “No address” are excluded so they cannot overwrite saved contact data.